### PR TITLE
add buff

### DIFF
--- a/Assets/Scenes/GameScene.unity
+++ b/Assets/Scenes/GameScene.unity
@@ -578,8 +578,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.5}
   m_AnchorMax: {x: 0, y: 0.5}
-  m_AnchoredPosition: {x: 154, y: -50}
-  m_SizeDelta: {x: 130, y: 130}
+  m_AnchoredPosition: {x: 154, y: -30}
+  m_SizeDelta: {x: 120, y: 120}
   m_Pivot: {x: 0, y: 0.5}
 --- !u!114 &670410285
 MonoBehaviour:
@@ -1340,8 +1340,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.5}
   m_AnchorMax: {x: 0, y: 0.5}
-  m_AnchoredPosition: {x: 14, y: -50}
-  m_SizeDelta: {x: 130, y: 130}
+  m_AnchoredPosition: {x: 14, y: -30}
+  m_SizeDelta: {x: 120, y: 120}
   m_Pivot: {x: 0, y: 0.5}
 --- !u!114 &950446994
 MonoBehaviour:
@@ -1725,8 +1725,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.5}
   m_AnchorMax: {x: 0, y: 0.5}
-  m_AnchoredPosition: {x: 294, y: -50}
-  m_SizeDelta: {x: 130, y: 130}
+  m_AnchoredPosition: {x: 294, y: -30}
+  m_SizeDelta: {x: 120, y: 120}
   m_Pivot: {x: 0, y: 0.5}
 --- !u!114 &1516677028
 MonoBehaviour:

--- a/Assets/Scripts/Buff.cs
+++ b/Assets/Scripts/Buff.cs
@@ -2,6 +2,7 @@
 
 public class StatBuff : Stat
 {
+
     public float maxHpPercent = 0; // 퍼센트로 증가할때 필요. 30% = 0.3f
     public float attackPercent = 0;
     public float defensePercent = 0;

--- a/Assets/Scripts/Buff.cs
+++ b/Assets/Scripts/Buff.cs
@@ -1,0 +1,32 @@
+﻿using System;
+
+public class StatBuff : Stat
+{
+    public float maxHpPercent = 0; // 퍼센트로 증가할때 필요. 30% = 0.3f
+    public float attackPercent = 0;
+    public float defensePercent = 0;
+    public float speedPercent = 0;
+    public int maxHpAbsolute = 0; // 절대치로 증가할때
+    public int attackAbsolute = 0;
+    public int defenseAbsolute = 0;
+    public int speedAbsolute = 0;
+
+    public void CalcStat(CharacterBase cb)
+    {
+        //*퍼센트로 붙은 버프를 적용하기전에 해당 캐릭터를 가져와 수치를 구한다.
+        //반드시 적용하기 전에 이 함수를 써서 수치를 구해야함. 
+        maxHp = (int)(maxHpPercent * cb.baseStat.maxHp) + maxHpAbsolute;
+        attack = (int)(attackPercent * cb.baseStat.attack) + attackAbsolute;
+        defense = (int)(defensePercent * cb.baseStat.defense) + defenseAbsolute;
+        speed = (int)(speedPercent * cb.baseStat.speed) + speedAbsolute;
+    }
+    public void CalcStat(Stat stat)
+    {
+        //*퍼센트로 붙은 버프를 적용하기전에 해당 캐릭터의 baseStat을 가져와 수치를 구한다.
+        //반드시 적용하기 전에 이 함수를 써서 수치를 구해야함. 
+        maxHp = (int)(maxHpPercent * stat.maxHp) + maxHpAbsolute;
+        attack = (int)(attackPercent * stat.attack) + attackAbsolute;
+        defense = (int)(defensePercent * stat.defense) + defenseAbsolute;
+        speed = (int)(speedPercent * stat.speed) + speedAbsolute;
+    }
+}

--- a/Assets/Scripts/Buff.cs
+++ b/Assets/Scripts/Buff.cs
@@ -16,10 +16,7 @@ public class StatBuff : Stat
     {
         //*퍼센트로 붙은 버프를 적용하기전에 해당 캐릭터를 가져와 수치를 구한다.
         //반드시 적용하기 전에 이 함수를 써서 수치를 구해야함. 
-        maxHp = (int)(maxHpPercent * cb.baseStat.maxHp) + maxHpAbsolute;
-        attack = (int)(attackPercent * cb.baseStat.attack) + attackAbsolute;
-        defense = (int)(defensePercent * cb.baseStat.defense) + defenseAbsolute;
-        speed = (int)(speedPercent * cb.baseStat.speed) + speedAbsolute;
+        this.CalcStat(cb.baseStat);
     }
     public void CalcStat(Stat stat)
     {

--- a/Assets/Scripts/Buff.cs.meta
+++ b/Assets/Scripts/Buff.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7737de3f00c377444a0abf61e18c0e55
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Character.cs
+++ b/Assets/Scripts/Character.cs
@@ -12,6 +12,7 @@ public class Stat
     public int speed;
     public int startSpeedGauge;
 
+
     public static Stat operator +(Stat a, Stat b)
     {
         return new Stat
@@ -23,7 +24,6 @@ public class Stat
             startSpeedGauge = a.startSpeedGauge + b.startSpeedGauge
         };
     }
-
     public override string ToString()
     {
         return $"Stat(hp:{maxHp}, atk:{attack}, def:{defense}, spd:{speed})";
@@ -58,20 +58,22 @@ public class Monster : CharacterBase
 
 public class Player : CharacterBase
 {
-    List<Stat> buffs = new List<Stat>();
+    StatBuff buff = new StatBuff();
     List<Stat> items = new List<Stat>();
 
     public Player(Stat stat) : base(stat) { }
 
-    public void AddBuff(Stat buff)
+    public void AddBuff(StatBuff buff)
     {
-        buffs.Add(buff);
+        this.buff = buff;
     }
 
     public override Stat GetStat()
     {
         Stat currentstat = this.baseStat;
-        currentstat = buffs.Aggregate(currentstat, (stat, buff) => stat + buff);
+        buff.CalcStat(this.baseStat);
+        currentstat = currentstat + buff;
+        // currentstat = buffs.Aggregate(currentstat, (stat, buff) => stat + buff);
         currentstat = items.Aggregate(currentstat, (stat, buff) => stat + buff);
         return currentstat;
     }

--- a/Assets/Scripts/Character.cs
+++ b/Assets/Scripts/Character.cs
@@ -51,8 +51,8 @@ public class CharacterBase
     }
 }
 
-public class Monster : CharacterBase 
-{ 
+public class Monster : CharacterBase
+{
     public Monster(Stat stat) : base(stat) { }
 }
 


### PR DESCRIPTION
버프가 절대치를 올리는 경우가 있고, 퍼센트로 올리는 경우가 있어서 Stat을 부모로 받는 StatBuff 클래스를 생성함. 버프의 경우 중첩이 되지않고 1가지만 적용되므로 character.cs에서 리스트로 안하고 변수 1개로 설정함. 퍼센트로 적용되는 경우 캐릭터의 스탯수치가 바뀔때마다 변동되는 스탯수치가 바뀌므로 CalcStat 메서드(함수)를 통해 변동되는 스탯값을 갱신해줘야함