### PR TITLE
버프판넬버튼 작동

### DIFF
--- a/Assets/Scenes/MainScene.unity
+++ b/Assets/Scenes/MainScene.unity
@@ -2595,7 +2595,18 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 838675356}
   m_OnClick:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 468903608}
+        m_MethodName: OnClickBuffButton
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!114 &838675356
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -4015,9 +4026,7 @@ MonoBehaviour:
   WorldNum: 1
   BossClear: 0
   UserScreen: {fileID: 0}
-  CardSelectPanel: {fileID: 1543311481}
   NpcPanel: {fileID: 1144839470}
-  BuffPanel: {fileID: 468903604}
 --- !u!1 &1233167275
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/MainScene.unity
+++ b/Assets/Scenes/MainScene.unity
@@ -1346,6 +1346,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e43632c8dcec8da4d80189cbe6d34bc7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  buffPanel: {fileID: 468903604}
+  cardSelectPanel: {fileID: 1543311481}
 --- !u!1 &510873290
 GameObject:
   m_ObjectHideFlags: 0
@@ -4026,7 +4028,9 @@ MonoBehaviour:
   WorldNum: 1
   BossClear: 0
   UserScreen: {fileID: 0}
+  CardSelectPanel: {fileID: 1543311481}
   NpcPanel: {fileID: 1144839470}
+  BuffPanel: {fileID: 468903604}
 --- !u!1 &1233167275
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/BuffPanelController.cs
+++ b/Assets/Scripts/BuffPanelController.cs
@@ -4,23 +4,29 @@ using UnityEngine;
 using UnityEngine.UI; 
 public class BuffPanelController : MonoBehaviour
 {
+
     GameObject buffName;
     GameObject buffDescription;
-  //  GameObject buffButton;
+    public GameObject buffPanel;
+    public GameObject cardSelectPanel;
     // Start is called before the first frame update
 
     void Start()
     {
         this.buffName = GameObject.Find("BuffName");
         this.buffDescription = GameObject.Find("BuffDescription");
-     //   this.buffButton = GameObject.Find("Button");
-        int i = Random.Range(1, 3);
+        int i = Random.Range(1, 3); // json 파일 버프 수가 늘어나면 바꾸기
         StatBuff buff =JsonDB.GetBuff($"buff{i}");
         buffName.GetComponent<Text>().text = buff.name;
         buffDescription.GetComponent<Text>().text = buff.description;
               
     }
     
+    public void OnClickBuffButton()
+    {
+        buffPanel.SetActive(false);
+        cardSelectPanel.SetActive(true);
+    }
     // Update is called once per frame
     void Update()
     {

--- a/Assets/Scripts/BuffPanelController.cs
+++ b/Assets/Scripts/BuffPanelController.cs
@@ -27,6 +27,7 @@ public class BuffPanelController : MonoBehaviour
         buffPanel.SetActive(false);
         cardSelectPanel.SetActive(true);
     }
+    
     // Update is called once per frame
     void Update()
     {

--- a/Assets/Scripts/StageChoice.cs
+++ b/Assets/Scripts/StageChoice.cs
@@ -62,18 +62,13 @@ public class StageChoice : MonoBehaviour
 
     List<Card> CardStates = new List<Card>()
     {
-        new Card(CardLocation.Left, CardType.Buff),
-        new Card(CardLocation.Middle, CardType.Buff),
-        new Card(CardLocation.Right, CardType.Buff),
-
-        new Card(CardLocation.Left, CardType.Npc), 
+        new Card(CardLocation.Left, CardType.Buff), 
         new Card(CardLocation.Middle, CardType.Npc), 
         new Card(CardLocation.Right, CardType.Npc),
 
         new Card(CardLocation.Left, CardType.Undecided), 
         new Card(CardLocation.Middle, CardType.Undecided), 
         new Card(CardLocation.Right, CardType.Undecided)
-  
     };
 
     // Start is called before the first frame update
@@ -97,6 +92,7 @@ public class StageChoice : MonoBehaviour
         UpdateGamePanel();
 
         // move forward
+        // TODO: Not yet completed
         CardStates[0] = CardStates[3];
         CardStates[1] = CardStates[4];
         CardStates[2] = CardStates[5];
@@ -164,7 +160,6 @@ public class StageChoice : MonoBehaviour
                 NpcPanel.SetActive(true);
                 NpcPanel.transform.localPosition = PanelDisplayPosition;
                 break;
-
         }
     }
 }


### PR DESCRIPTION
일단은 누르면 버프판넬 비활성화되고 카드선택판넬이 활성화되게 함.
사실 버튼 누르면 버프가 적용되게 하고 싶은데 아직 플레이어 스탯이 형성되지 않아서 넣지않음