### PR TITLE
상자패널이름 수정 + 전투부분패널 추가

### DIFF
--- a/Assets/Scenes/MainScene.unity
+++ b/Assets/Scenes/MainScene.unity
@@ -1178,12 +1178,12 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 1664559585}
-        m_MethodName: OnClickHandCard3
-        m_Mode: 1
+        m_MethodName: OnClickHandCard
+        m_Mode: 3
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
+          m_IntArgument: 3
           m_FloatArgument: 0
           m_StringArgument: 
           m_BoolArgument: 0
@@ -5624,12 +5624,12 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 1664559585}
-        m_MethodName: OnClickHandCard1
-        m_Mode: 1
+        m_MethodName: OnClickHandCard
+        m_Mode: 3
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
+          m_IntArgument: 1
           m_FloatArgument: 0
           m_StringArgument: 
           m_BoolArgument: 0
@@ -6420,12 +6420,12 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 1664559585}
-        m_MethodName: OnClickHandCard2
-        m_Mode: 1
+        m_MethodName: OnClickHandCard
+        m_Mode: 3
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
+          m_IntArgument: 2
           m_FloatArgument: 0
           m_StringArgument: 
           m_BoolArgument: 0
@@ -8154,12 +8154,12 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 1664559585}
-        m_MethodName: OnClickHandCard4
-        m_Mode: 1
+        m_MethodName: OnClickHandCard
+        m_Mode: 3
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
+          m_IntArgument: 4
           m_FloatArgument: 0
           m_StringArgument: 
           m_BoolArgument: 0

--- a/Assets/Scenes/MainScene.unity
+++ b/Assets/Scenes/MainScene.unity
@@ -1803,7 +1803,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   buffPanel: {fileID: 468903604}
-  cardSelectPanel: {fileID: 1186672454}
+  cardSelectPanel: {fileID: 1543311481}
 --- !u!1 &510873290
 GameObject:
   m_ObjectHideFlags: 0
@@ -2989,7 +2989,7 @@ GameObject:
   - component: {fileID: 761889049}
   - component: {fileID: 761889048}
   m_Layer: 5
-  m_Name: TreasurePanel
+  m_Name: ChestPanel
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -3030,10 +3030,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4106975501135484f9a1ca9c2eeced9d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  cardSelectPanel: {fileID: 1186672454}
+  cardSelectPanel: {fileID: 1543311481}
   chestPanel: {fileID: 761889046}
-  chestType: {fileID: 0}
-  chestDescription: {fileID: 0}
+  chestType: {fileID: 1211386216}
+  chestDescription: {fileID: 772557087}
 --- !u!114 &761889049
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3083,7 +3083,7 @@ GameObject:
   - component: {fileID: 772557090}
   - component: {fileID: 772557089}
   m_Layer: 5
-  m_Name: TreasureDescription
+  m_Name: ChestDescription
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -5183,7 +5183,7 @@ GameObject:
   - component: {fileID: 1211386219}
   - component: {fileID: 1211386218}
   m_Layer: 5
-  m_Name: TreasureType
+  m_Name: ChestType
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0

--- a/Assets/Scenes/MainScene.unity
+++ b/Assets/Scenes/MainScene.unity
@@ -200,6 +200,84 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4919391}
   m_CullTransparentMesh: 0
+--- !u!1 &26617691
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 26617694}
+  - component: {fileID: 26617693}
+  - component: {fileID: 26617692}
+  m_Layer: 5
+  m_Name: DeckCount
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &26617692
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 26617691}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 40
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 3
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 1
+    m_VerticalOverflow: 1
+    m_LineSpacing: 1
+  m_Text: "\uB0A8\uC740 \uB301"
+--- !u!222 &26617693
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 26617691}
+  m_CullTransparentMesh: 0
+--- !u!224 &26617694
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 26617691}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1664559588}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 200, y: 50}
+  m_Pivot: {x: 1, y: 1}
 --- !u!1 &55830239
 GameObject:
   m_ObjectHideFlags: 0
@@ -608,6 +686,84 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 154160906}
   m_CullTransparentMesh: 0
+--- !u!1 &176949642
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 176949643}
+  - component: {fileID: 176949645}
+  - component: {fileID: 176949644}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &176949643
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 176949642}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1904303699}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &176949644
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 176949642}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 40
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 2
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: "\uACF5\uACA9\uD558\uAE30"
+--- !u!222 &176949645
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 176949642}
+  m_CullTransparentMesh: 0
 --- !u!1 &212763577
 GameObject:
   m_ObjectHideFlags: 0
@@ -959,6 +1115,136 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 242104029}
   m_CullTransparentMesh: 0
+--- !u!1 &260106159
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 260106163}
+  - component: {fileID: 260106162}
+  - component: {fileID: 260106161}
+  - component: {fileID: 260106160}
+  m_Layer: 5
+  m_Name: HandCard3
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &260106160
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 260106159}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 260106161}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1664559585}
+        m_MethodName: OnClickHandCard3
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &260106161
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 260106159}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &260106162
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 260106159}
+  m_CullTransparentMesh: 0
+--- !u!224 &260106163
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 260106159}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 830929846}
+  m_Father: {fileID: 1664559588}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0}
+  m_AnchorMax: {x: 0.5, y: 0}
+  m_AnchoredPosition: {x: 122, y: 10}
+  m_SizeDelta: {x: 200, y: 300}
+  m_Pivot: {x: 0.5, y: 0}
 --- !u!1 &276718437
 GameObject:
   m_ObjectHideFlags: 0
@@ -1746,7 +2032,7 @@ RectTransform:
   - {fileID: 1101563936}
   - {fileID: 838675354}
   m_Father: {fileID: 1186672458}
-  m_RootOrder: 5
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.5}
   m_AnchorMax: {x: 1, y: 0.5}
@@ -2898,6 +3184,84 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 715866911}
   m_CullTransparentMesh: 0
+--- !u!1 &718356012
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 718356013}
+  - component: {fileID: 718356015}
+  - component: {fileID: 718356014}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &718356013
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 718356012}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1145485629}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &718356014
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 718356012}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 40
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 4
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: "\uCE74\uB4DC1"
+--- !u!222 &718356015
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 718356012}
+  m_CullTransparentMesh: 0
 --- !u!1 &741339886
 GameObject:
   m_ObjectHideFlags: 0
@@ -3011,7 +3375,7 @@ RectTransform:
   - {fileID: 772557088}
   - {fileID: 2104822452}
   m_Father: {fileID: 1186672458}
-  m_RootOrder: 6
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.5}
   m_AnchorMax: {x: 1, y: 0.5}
@@ -3300,6 +3664,84 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 808964882}
+  m_CullTransparentMesh: 0
+--- !u!1 &830929845
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 830929846}
+  - component: {fileID: 830929848}
+  - component: {fileID: 830929847}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &830929846
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 830929845}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 260106163}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &830929847
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 830929845}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 40
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 4
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: "\uCE74\uB4DC3"
+--- !u!222 &830929848
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 830929845}
   m_CullTransparentMesh: 0
 --- !u!1 &836546046
 GameObject:
@@ -4045,6 +4487,84 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 897429039}
+  m_CullTransparentMesh: 0
+--- !u!1 &916422529
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 916422530}
+  - component: {fileID: 916422532}
+  - component: {fileID: 916422531}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &916422530
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 916422529}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 2125184057}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &916422531
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 916422529}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 40
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 4
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: "\uCE74\uB4DC4"
+--- !u!222 &916422532
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 916422529}
   m_CullTransparentMesh: 0
 --- !u!1 &926264864
 GameObject:
@@ -5041,6 +5561,136 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   NpcItemIds: []
   stageChoice: {fileID: 1186672459}
+--- !u!1 &1145485625
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1145485629}
+  - component: {fileID: 1145485628}
+  - component: {fileID: 1145485627}
+  - component: {fileID: 1145485626}
+  m_Layer: 5
+  m_Name: HandCard1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1145485626
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1145485625}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1145485627}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1664559585}
+        m_MethodName: OnClickHandCard1
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &1145485627
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1145485625}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1145485628
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1145485625}
+  m_CullTransparentMesh: 0
+--- !u!224 &1145485629
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1145485625}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 718356013}
+  m_Father: {fileID: 1664559588}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0}
+  m_AnchorMax: {x: 0.5, y: 0}
+  m_AnchoredPosition: {x: -391, y: 10}
+  m_SizeDelta: {x: 200, y: 300}
+  m_Pivot: {x: 0.5, y: 0}
 --- !u!1 &1186672454
 GameObject:
   m_ObjectHideFlags: 0
@@ -5137,6 +5787,7 @@ RectTransform:
   - {fileID: 1144839471}
   - {fileID: 383879197}
   - {fileID: 1502824054}
+  - {fileID: 1664559588}
   - {fileID: 468903605}
   - {fileID: 761889047}
   - {fileID: 1308726067}
@@ -5168,6 +5819,7 @@ MonoBehaviour:
   NpcPanel: {fileID: 1144839470}
   BuffPanel: {fileID: 468903604}
   ChestPanel: {fileID: 761889046}
+  BattlePanel: {fileID: 1664559584}
   card1_text: {fileID: 972353967}
   card2_text: {fileID: 1933146089}
   card3_text: {fileID: 575380911}
@@ -5361,7 +6013,7 @@ RectTransform:
   - {fileID: 385546367}
   - {fileID: 1918254848}
   m_Father: {fileID: 1186672458}
-  m_RootOrder: 7
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -5705,6 +6357,136 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1468148775}
   m_CullTransparentMesh: 0
+--- !u!1 &1490778127
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1490778131}
+  - component: {fileID: 1490778130}
+  - component: {fileID: 1490778129}
+  - component: {fileID: 1490778128}
+  m_Layer: 5
+  m_Name: HandCard2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1490778128
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1490778127}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1490778129}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1664559585}
+        m_MethodName: OnClickHandCard2
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &1490778129
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1490778127}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1490778130
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1490778127}
+  m_CullTransparentMesh: 0
+--- !u!224 &1490778131
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1490778127}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1704135054}
+  m_Father: {fileID: 1664559588}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0}
+  m_AnchorMax: {x: 0.5, y: 0}
+  m_AnchoredPosition: {x: -134, y: 10}
+  m_SizeDelta: {x: 200, y: 300}
+  m_Pivot: {x: 0.5, y: 0}
 --- !u!1 &1502824053
 GameObject:
   m_ObjectHideFlags: 0
@@ -5957,6 +6739,105 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1655139288}
   m_CullTransparentMesh: 0
+--- !u!1 &1664559584
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1664559588}
+  - component: {fileID: 1664559587}
+  - component: {fileID: 1664559586}
+  - component: {fileID: 1664559585}
+  m_Layer: 5
+  m_Name: BattlePlayerAttackPanel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1664559585
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1664559584}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0bd3672306a62d241a665148086a2d3a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  handCard1: {fileID: 1145485625}
+  handCard2: {fileID: 1490778127}
+  handCard3: {fileID: 260106159}
+  handCard4: {fileID: 2125184053}
+  deckCount: {fileID: 26617691}
+  selectCard: 00000000
+--- !u!114 &1664559586
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1664559584}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.392}
+  m_RaycastTarget: 1
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1664559587
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1664559584}
+  m_CullTransparentMesh: 0
+--- !u!224 &1664559588
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1664559584}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1145485629}
+  - {fileID: 1490778131}
+  - {fileID: 260106163}
+  - {fileID: 2125184057}
+  - {fileID: 1904303699}
+  - {fileID: 26617694}
+  m_Father: {fileID: 1186672458}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 1, y: 0.5}
+  m_AnchoredPosition: {x: 1500, y: 1600}
+  m_SizeDelta: {x: 0, y: 1200}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1677008404
 GameObject:
   m_ObjectHideFlags: 0
@@ -6112,6 +6993,84 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1679003938}
+  m_CullTransparentMesh: 0
+--- !u!1 &1704135053
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1704135054}
+  - component: {fileID: 1704135056}
+  - component: {fileID: 1704135055}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1704135054
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1704135053}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1490778131}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1704135055
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1704135053}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 40
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 4
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: "\uCE74\uB4DC2"
+--- !u!222 &1704135056
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1704135053}
   m_CullTransparentMesh: 0
 --- !u!1 &1722549970
 GameObject:
@@ -6643,6 +7602,136 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1886371695}
   m_CullTransparentMesh: 0
+--- !u!1 &1904303695
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1904303699}
+  - component: {fileID: 1904303698}
+  - component: {fileID: 1904303697}
+  - component: {fileID: 1904303696}
+  m_Layer: 5
+  m_Name: AttackButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1904303696
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1904303695}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1904303697}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1664559585}
+        m_MethodName: OnClickAttack
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &1904303697
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1904303695}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1904303698
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1904303695}
+  m_CullTransparentMesh: 0
+--- !u!224 &1904303699
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1904303695}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 176949643}
+  m_Father: {fileID: 1664559588}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 200, y: 200}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1918254847
 GameObject:
   m_ObjectHideFlags: 0
@@ -7002,3 +8091,133 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2110697517}
   m_CullTransparentMesh: 0
+--- !u!1 &2125184053
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2125184057}
+  - component: {fileID: 2125184056}
+  - component: {fileID: 2125184055}
+  - component: {fileID: 2125184054}
+  m_Layer: 5
+  m_Name: HandCard4
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &2125184054
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2125184053}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 2125184055}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1664559585}
+        m_MethodName: OnClickHandCard4
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &2125184055
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2125184053}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &2125184056
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2125184053}
+  m_CullTransparentMesh: 0
+--- !u!224 &2125184057
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2125184053}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 916422530}
+  m_Father: {fileID: 1664559588}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0}
+  m_AnchorMax: {x: 0.5, y: 0}
+  m_AnchoredPosition: {x: 380, y: 10}
+  m_SizeDelta: {x: 200, y: 300}
+  m_Pivot: {x: 0.5, y: 0}

--- a/Assets/Scripts/BattlePlayerAttackPanelController.cs
+++ b/Assets/Scripts/BattlePlayerAttackPanelController.cs
@@ -71,95 +71,33 @@ public class BattlePlayerAttackPanelController : MonoBehaviour
 {
     const int HAND_MAX = 4; //최대 핸드 수
     const int SELECT_MAX = 3; // 선택가능한 핸드의 카드 수
-    public GameObject handCard1;
-    public GameObject handCard2;
-    public GameObject handCard3;
-    public GameObject handCard4;
+    GameObject[] handCard = new GameObject[HAND_MAX] ;
     public GameObject deckCount;
     public bool[] selectCard = new bool[HAND_MAX];
     public List<Weapon> playerWeapons =new List<Weapon>();
     public Battle battle = new Battle();
     //버튼이 토글처럼 되도록 했고, 최대 HAND_MAX(=3)만큼만 선택이 되도록 함.
-    public void OnClickHandCard1()
+    public void OnClickHandCard(int index)
     {
-        if ((from n in selectCard where n == true select n).Count() < SELECT_MAX || selectCard[0]==true)
+        if ((from n in selectCard where n == true select n).Count() < SELECT_MAX || selectCard[index] ==true)
         {
-            selectCard[0] = !(selectCard[0]);
+            selectCard[index] = !(selectCard[index]);
 
-            if (selectCard[0])
+            if (selectCard[index])
             {
-                ColorBlock colorBlock = handCard1.GetComponent<Button>().colors;
+                ColorBlock colorBlock = handCard[index].GetComponent<Button>().colors;
                 colorBlock.selectedColor = colorBlock.normalColor = colorBlock.highlightedColor = Color.gray;
-                handCard1.GetComponent<Button>().colors = colorBlock;
+                handCard[index].GetComponent<Button>().colors = colorBlock;
             }
             else
             {
-                ColorBlock colorBlock = handCard1.GetComponent<Button>().colors;
+                ColorBlock colorBlock = handCard[index].GetComponent<Button>().colors;
                 colorBlock.selectedColor = colorBlock.normalColor = colorBlock.highlightedColor = Color.white;
-                handCard1.GetComponent<Button>().colors = colorBlock;
+                handCard[index].GetComponent<Button>().colors = colorBlock;
             }
         }
      }
-    //버튼이 토글처럼 되도록 했고, 최대 HAND_MAX(=3)만큼만 선택이 되도록 함.
-    public void OnClickHandCard2()
-    {
-        if ((from n in selectCard where n == true select n).Count() < SELECT_MAX || selectCard[1] == true)
-        {
-            selectCard[1] = !(selectCard[1]);
-            if (selectCard[1])
-            {
-                ColorBlock colorBlock = handCard2.GetComponent<Button>().colors;
-                colorBlock.selectedColor = colorBlock.normalColor = colorBlock.highlightedColor = Color.gray;
-                handCard2.GetComponent<Button>().colors = colorBlock;
-            }
-            else
-            {
-                ColorBlock colorBlock = handCard2.GetComponent<Button>().colors;
-                colorBlock.selectedColor = colorBlock.normalColor = colorBlock.highlightedColor = Color.white;
-                handCard2.GetComponent<Button>().colors = colorBlock;
-            }
-        }
-    }
-    //버튼이 토글처럼 되도록 했고, 최대 HAND_MAX(=3)만큼만 선택이 되도록 함.
-    public void OnClickHandCard3()
-    {
-        if ((from n in selectCard where n == true select n).Count() < SELECT_MAX || selectCard[2] == true)
-        {
-            selectCard[2] = !(selectCard[2]);
-            if (selectCard[2])
-            {
-                ColorBlock colorBlock = handCard3.GetComponent<Button>().colors;
-                colorBlock.selectedColor = colorBlock.normalColor = colorBlock.highlightedColor = Color.gray;
-                handCard3.GetComponent<Button>().colors = colorBlock;
-            }
-            else
-            {
-                ColorBlock colorBlock = handCard3.GetComponent<Button>().colors;
-                colorBlock.selectedColor = colorBlock.normalColor = colorBlock.highlightedColor = Color.white;
-                handCard3.GetComponent<Button>().colors = colorBlock;
-            }
-        }
-    }
-    //버튼이 토글처럼 되도록 했고, 최대 HAND_MAX(=3)만큼만 선택이 되도록 함.
-    public void OnClickHandCard4()
-    {
-        if ((from n in selectCard where n == true select n).Count() < SELECT_MAX || selectCard[3] == true)
-        {
-            selectCard[3] = !(selectCard[3]);
-            if (selectCard[3])
-            {
-                ColorBlock colorBlock = handCard4.GetComponent<Button>().colors;
-                colorBlock.selectedColor = colorBlock.normalColor = colorBlock.highlightedColor = Color.gray;
-                handCard4.GetComponent<Button>().colors = colorBlock;
-            }
-            else
-            {
-                ColorBlock colorBlock = handCard4.GetComponent<Button>().colors;
-                colorBlock.selectedColor = colorBlock.normalColor = colorBlock.highlightedColor = Color.white;
-                handCard4.GetComponent<Button>().colors = colorBlock;
-            }
-        }
-    }
+   
 
     public void OnClickAttack()
     {
@@ -172,21 +110,7 @@ public class BattlePlayerAttackPanelController : MonoBehaviour
                 //정해진 카드를 모아서 attack매서드에 전달 후, 핸드에 있는 카드를 제거
                 sum += battle.CardHand.ElementAt(i).statEffect.attack;
                 battle.CardHand.RemoveAt(i); // 지금은 제거만 했음.
-                switch (i) { //선택된 버튼을 다시 눌러서 초기화
-                    case 0:
-                        OnClickHandCard1();
-                        break;
-                    case 1:
-                        OnClickHandCard2();
-                        break;
-                    case 2:
-                        OnClickHandCard3();
-                        break;
-                    case 3:
-                        OnClickHandCard4();
-                        break;
-                }
-
+                OnClickHandCard(i); //버튼을 다시 눌러서 초기화           
             }          
         }
         Debug.Log($"attack : {sum}");
@@ -230,16 +154,19 @@ public class BattlePlayerAttackPanelController : MonoBehaviour
     // Start is called before the first frame update
     void Start()
     {
-
+        for (int i = 0; i < HAND_MAX; i++) 
+        {
+            handCard[i] = GameObject.Find($"HandCard{i + 1}");
+        }
     }
 
     // Update is called once per frame
     void Update()
-    {                
-        handCard1.transform.GetChild(0).GetComponent<Text>().text = $"{battle.CardHand.ElementAt(0).statEffect}";
-        handCard2.transform.GetChild(0).GetComponent<Text>().text = $"{battle.CardHand.ElementAt(1).statEffect}";
-        handCard3.transform.GetChild(0).GetComponent<Text>().text = $"{battle.CardHand.ElementAt(2).statEffect}";
-        handCard4.transform.GetChild(0).GetComponent<Text>().text = $"{battle.CardHand.ElementAt(3).statEffect}";
+    {
+        for (int i = 0; i < HAND_MAX; i++)
+        {
+            handCard[i].transform.GetChild(0).GetComponent<Text>().text = $"{battle.CardHand.ElementAt(i).statEffect}";
+        }
         deckCount.GetComponent<Text>().text = $"{battle.DeckCount()}";
     }
 }

--- a/Assets/Scripts/BattlePlayerAttackPanelController.cs
+++ b/Assets/Scripts/BattlePlayerAttackPanelController.cs
@@ -1,0 +1,245 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+using System.Linq;
+
+//아직 배틀 클래스가 없어서 임시로 만듬 나중에 정섭이 코드 나오면 합쳐야함
+public partial class Battle 
+{
+    const int HAND_MAX = 4; //최대 핸드 수
+    public List<Weapon> CardList = new List<Weapon>(); //CardList는 플레이어의 웨폰리스트를 가져와야함.
+    public List<Weapon> CardDeck = new List<Weapon>();
+    public List<Weapon> CardHand = new List<Weapon>();
+
+    //기존의 카드댁,핸드 초기화하고 리스트에서 댁을 불러와 섞는것까지 하는 메서드
+    public void BattleStart() 
+    {
+        CardDeck.Clear();
+        CardHand.Clear();
+        CardDeck.AddRange(CardList);
+        Shuffle(CardDeck);
+        Draw(CardDeck, CardHand, HAND_MAX);
+    }
+
+    //카드를 랜덤으로 섞기위한 메서드
+    public static void Shuffle<T>(List<T> list) 
+    {
+        System.Random rng = new System.Random();
+        int n = list.Count;
+        while (n > 1)
+        {
+            n--;
+            int k = rng.Next(n + 1);
+            T value = list[k];
+            list[k] = list[n];
+            list[n] = value;
+        }
+    }
+
+    //카드를 드로우하는 매소드 (카드댁,핸드,드로우의 수) , 리턴값은 부족한 카드의 수
+    public static int Draw<T>(List<T> deckList, List<T> handList, int n)
+    {
+        if (deckList.Count < n) // n 장 드로우 해야하는 데, 댁의 카드가 그보다 적을 경우
+        {
+            int count = 0;
+            while (deckList.Count != 0)
+            {
+                handList.AddRange(deckList.GetRange(0, 1));
+                deckList.RemoveRange(0, 1);
+                count++;
+            }
+            Debug.Log($"카드 부족 !!! {n - count}장 ");
+            return n - count; //부족한 카드 수를 리턴
+        }
+        else
+        {
+            handList.AddRange(deckList.GetRange(0, n));
+            deckList.RemoveRange(0, n);
+            return 0; //부족한 카드 없이 모두 뽑았으므로 0을 리턴
+        }
+    }
+
+    public int DeckCount()
+    {
+        return CardDeck.Count();
+    }
+
+}
+
+public class BattlePlayerAttackPanelController : MonoBehaviour
+{
+    const int HAND_MAX = 4; //최대 핸드 수
+    const int SELECT_MAX = 3; // 선택가능한 핸드의 카드 수
+    public GameObject handCard1;
+    public GameObject handCard2;
+    public GameObject handCard3;
+    public GameObject handCard4;
+    public GameObject deckCount;
+    public bool[] selectCard = new bool[HAND_MAX];
+    public List<Weapon> playerWeapons =new List<Weapon>();
+    public Battle battle = new Battle();
+    //버튼이 토글처럼 되도록 했고, 최대 HAND_MAX(=3)만큼만 선택이 되도록 함.
+    public void OnClickHandCard1()
+    {
+        if ((from n in selectCard where n == true select n).Count() < SELECT_MAX || selectCard[0]==true)
+        {
+            selectCard[0] = !(selectCard[0]);
+
+            if (selectCard[0])
+            {
+                ColorBlock colorBlock = handCard1.GetComponent<Button>().colors;
+                colorBlock.selectedColor = colorBlock.normalColor = colorBlock.highlightedColor = Color.gray;
+                handCard1.GetComponent<Button>().colors = colorBlock;
+            }
+            else
+            {
+                ColorBlock colorBlock = handCard1.GetComponent<Button>().colors;
+                colorBlock.selectedColor = colorBlock.normalColor = colorBlock.highlightedColor = Color.white;
+                handCard1.GetComponent<Button>().colors = colorBlock;
+            }
+        }
+     }
+    //버튼이 토글처럼 되도록 했고, 최대 HAND_MAX(=3)만큼만 선택이 되도록 함.
+    public void OnClickHandCard2()
+    {
+        if ((from n in selectCard where n == true select n).Count() < SELECT_MAX || selectCard[1] == true)
+        {
+            selectCard[1] = !(selectCard[1]);
+            if (selectCard[1])
+            {
+                ColorBlock colorBlock = handCard2.GetComponent<Button>().colors;
+                colorBlock.selectedColor = colorBlock.normalColor = colorBlock.highlightedColor = Color.gray;
+                handCard2.GetComponent<Button>().colors = colorBlock;
+            }
+            else
+            {
+                ColorBlock colorBlock = handCard2.GetComponent<Button>().colors;
+                colorBlock.selectedColor = colorBlock.normalColor = colorBlock.highlightedColor = Color.white;
+                handCard2.GetComponent<Button>().colors = colorBlock;
+            }
+        }
+    }
+    //버튼이 토글처럼 되도록 했고, 최대 HAND_MAX(=3)만큼만 선택이 되도록 함.
+    public void OnClickHandCard3()
+    {
+        if ((from n in selectCard where n == true select n).Count() < SELECT_MAX || selectCard[2] == true)
+        {
+            selectCard[2] = !(selectCard[2]);
+            if (selectCard[2])
+            {
+                ColorBlock colorBlock = handCard3.GetComponent<Button>().colors;
+                colorBlock.selectedColor = colorBlock.normalColor = colorBlock.highlightedColor = Color.gray;
+                handCard3.GetComponent<Button>().colors = colorBlock;
+            }
+            else
+            {
+                ColorBlock colorBlock = handCard3.GetComponent<Button>().colors;
+                colorBlock.selectedColor = colorBlock.normalColor = colorBlock.highlightedColor = Color.white;
+                handCard3.GetComponent<Button>().colors = colorBlock;
+            }
+        }
+    }
+    //버튼이 토글처럼 되도록 했고, 최대 HAND_MAX(=3)만큼만 선택이 되도록 함.
+    public void OnClickHandCard4()
+    {
+        if ((from n in selectCard where n == true select n).Count() < SELECT_MAX || selectCard[3] == true)
+        {
+            selectCard[3] = !(selectCard[3]);
+            if (selectCard[3])
+            {
+                ColorBlock colorBlock = handCard4.GetComponent<Button>().colors;
+                colorBlock.selectedColor = colorBlock.normalColor = colorBlock.highlightedColor = Color.gray;
+                handCard4.GetComponent<Button>().colors = colorBlock;
+            }
+            else
+            {
+                ColorBlock colorBlock = handCard4.GetComponent<Button>().colors;
+                colorBlock.selectedColor = colorBlock.normalColor = colorBlock.highlightedColor = Color.white;
+                handCard4.GetComponent<Button>().colors = colorBlock;
+            }
+        }
+    }
+
+    public void OnClickAttack()
+    {
+        int sum = 0;
+        int maxCount = (from n in selectCard where n == true select n).Count();
+        for(int i= HAND_MAX-1; i>=0;i--)
+        {
+            if (selectCard[i] == true) //손에서 정해진 카드를 battle 클래스에 전달
+            {
+                //정해진 카드를 모아서 attack매서드에 전달 후, 핸드에 있는 카드를 제거
+                sum += battle.CardHand.ElementAt(i).statEffect.attack;
+                battle.CardHand.RemoveAt(i); // 지금은 제거만 했음.
+                switch (i) { //선택된 버튼을 다시 눌러서 초기화
+                    case 0:
+                        OnClickHandCard1();
+                        break;
+                    case 1:
+                        OnClickHandCard2();
+                        break;
+                    case 2:
+                        OnClickHandCard3();
+                        break;
+                    case 3:
+                        OnClickHandCard4();
+                        break;
+                }
+
+            }          
+        }
+        Debug.Log($"attack : {sum}");
+        int checkDraw = 0;      
+        checkDraw =Battle.Draw(battle.CardDeck,battle.CardHand,maxCount);
+        if (0 != checkDraw)
+        {
+            battle.CardDeck.AddRange(battle.CardList);
+            Battle.Shuffle(battle.CardDeck);
+            Battle.Draw(battle.CardDeck, battle.CardHand, checkDraw);
+        }
+    }
+    //해당 패널이 활성화 될때 실행되는 메서드
+    private void OnEnable()
+    {
+        //*나중에 플레이어 클래스에 웨폰리스트가 추가되면 이 코드 삭제하기*
+      var stat = new Stat()
+        {
+            attack = 5
+        };
+        var weapon = new Weapon() { statEffect = stat };
+
+        playerWeapons.Clear();
+        for (int i = 0; i < 5; i++)
+        {
+            playerWeapons.Add(weapon);
+        }
+        var stat1 = new Stat()
+        {
+            attack = 10
+        };
+        var weapon1 = new Weapon() { statEffect = stat1 };
+        for (int i = 0; i < 5; i++)
+        {
+            playerWeapons.Add(weapon1);
+        }
+
+        battle.CardList = playerWeapons;
+        battle.BattleStart();      
+    }
+    // Start is called before the first frame update
+    void Start()
+    {
+
+    }
+
+    // Update is called once per frame
+    void Update()
+    {                
+        handCard1.transform.GetChild(0).GetComponent<Text>().text = $"{battle.CardHand.ElementAt(0).statEffect}";
+        handCard2.transform.GetChild(0).GetComponent<Text>().text = $"{battle.CardHand.ElementAt(1).statEffect}";
+        handCard3.transform.GetChild(0).GetComponent<Text>().text = $"{battle.CardHand.ElementAt(2).statEffect}";
+        handCard4.transform.GetChild(0).GetComponent<Text>().text = $"{battle.CardHand.ElementAt(3).statEffect}";
+        deckCount.GetComponent<Text>().text = $"{battle.DeckCount()}";
+    }
+}

--- a/Assets/Scripts/BattlePlayerAttackPanelController.cs
+++ b/Assets/Scripts/BattlePlayerAttackPanelController.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 using UnityEngine.UI;
 using System.Linq;
 
-//아직 배틀 클래스가 없어서 임시로 만듬 나중에 정섭이 코드 나오면 합쳐야함
+//TODO:아직 배틀 클래스가 없어서 임시로 만듬 나중에 정섭이 코드 나오면 합쳐야함
 public partial class Battle 
 {
     const int HAND_MAX = 4; //최대 핸드 수
@@ -107,6 +107,7 @@ public class BattlePlayerAttackPanelController : MonoBehaviour
         {
             if (selectCard[i] == true) //손에서 정해진 카드를 battle 클래스에 전달
             {
+                //TODO: 나중에 데미지 관련(시너지)하여 추가해야함
                 //정해진 카드를 모아서 attack매서드에 전달 후, 핸드에 있는 카드를 제거
                 sum += battle.CardHand.ElementAt(i).statEffect.attack;
                 battle.CardHand.RemoveAt(i); // 지금은 제거만 했음.
@@ -126,8 +127,8 @@ public class BattlePlayerAttackPanelController : MonoBehaviour
     //해당 패널이 활성화 될때 실행되는 메서드
     private void OnEnable()
     {
-        //*나중에 플레이어 클래스에 웨폰리스트가 추가되면 이 코드 삭제하기*
-      var stat = new Stat()
+        // TODO:나중에 플레이어 클래스에 웨폰리스트가 추가되면 이 코드 삭제하기
+        var stat = new Stat()
         {
             attack = 5
         };

--- a/Assets/Scripts/BattlePlayerAttackPanelController.cs.meta
+++ b/Assets/Scripts/BattlePlayerAttackPanelController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0bd3672306a62d241a665148086a2d3a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/StageChoice.cs
+++ b/Assets/Scripts/StageChoice.cs
@@ -59,6 +59,7 @@ public class StageChoice : MonoBehaviour
     public GameObject NpcPanel;
     public GameObject BuffPanel;
     public GameObject ChestPanel;
+    public GameObject BattlePanel;
     public System.Random ran = new System.Random();
 
     List<Card> CardStates = new List<Card>()
@@ -151,6 +152,7 @@ public class StageChoice : MonoBehaviour
         NpcPanel.SetActive(false);
         BuffPanel.SetActive(false);
         ChestPanel.SetActive(false);
+        BattlePanel.SetActive(false);
     }
 
     public void UpdateGamePanel()
@@ -162,6 +164,8 @@ public class StageChoice : MonoBehaviour
                 CardSelectPanel.transform.localPosition = PanelDisplayPosition;
                 break;
             case CardType.Monster:
+                BattlePanel.SetActive(true);
+                BattlePanel.transform.localPosition = PanelDisplayPosition;
                 break;
             case CardType.Chest:
                 ChestPanel.SetActive(true);


### PR DESCRIPTION
배틀 부분에서 무기 10개(장)를 이용해 카드를 돌리는 부분을 구현함.
배틀의 다른 부분이 미완성이라서 완벽하게 완성된 것은 아님.
패널 추가로 monster 카드를 누르면 돌아가게 설정함.
기본 카드 4개가 주어지고, 그중에서 0~3개까지 선택하여 공격할 수 있음.
선택되지 않은 카드는 왼쪽으로 정렬되고 남은 카드가 댁에서 채워지는 방식.
오른쪽 위에 댁에서 남은 카드를 숫자로 표시함.
댁의 카드가 없으면 무기 10장을 다시 셔플해서 댁에 채우고 뽑는 방식(손의 있는 카드는 그대로)