### PR TITLE
Equipment fix sangyeon

### DIFF
--- a/Assets/Scenes/MainScene.unity
+++ b/Assets/Scenes/MainScene.unity
@@ -2197,7 +2197,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   buffView: {fileID: 0}
   buffPanel: {fileID: 468903604}
-  cardSelectPanel: {fileID: 1543311481}
+  stageChoice: {fileID: 1186672459}
   buffSummary: {fileID: 91948238}
   buffUpdate: 0
   str: "\uBC84\uD504 \uC5C6\uC74C"
@@ -3506,10 +3506,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4106975501135484f9a1ca9c2eeced9d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  cardSelectPanel: {fileID: 1543311481}
   chestPanel: {fileID: 761889046}
   chestType: {fileID: 1211386216}
   chestDescription: {fileID: 772557087}
+  stageChoice: {fileID: 1186672459}
 --- !u!114 &761889049
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -5923,7 +5923,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e0a3d51cfb81bf641af1e5cd84259645, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  UserScreen: {fileID: 0}
 --- !u!1 &1211386216
 GameObject:
   m_ObjectHideFlags: 0
@@ -6875,6 +6874,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   deckCount: {fileID: 26617691}
   selectCard: 00000000
+  stageChoice: {fileID: 1186672459}
+  isBattle: 0
 --- !u!114 &1664559586
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/MainScene.unity
+++ b/Assets/Scenes/MainScene.unity
@@ -854,6 +854,7 @@ GameObject:
   - component: {fileID: 212763579}
   - component: {fileID: 212763578}
   - component: {fileID: 212763581}
+  - component: {fileID: 212763582}
   m_Layer: 0
   m_Name: EventSystem
   m_TagString: Untagged
@@ -919,6 +920,18 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 686b955b292dd694ea5228a489272eac, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &212763582
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 212763577}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8be70489c84a2bc44a981ea592855c24, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &222413878

--- a/Assets/Scripts/BattlePlayerAttackPanelController.cs
+++ b/Assets/Scripts/BattlePlayerAttackPanelController.cs
@@ -254,28 +254,9 @@ public class BattlePlayerAttackPanelController : MonoBehaviour
     //해당 패널이 활성화 될때 실행되는 메서드
     private void OnEnable()
     {
-        // TODO:나중에 플레이어 클래스에 웨폰리스트가 추가되면 이 코드 삭제하기
-        var stat = new Stat()
-        {
-            attack = 5
-        };
-        var weapon = new Weapon() { statEffect = stat };
-
+        //플레이어의 무기10장을 가져와서 cardlist에 복사한다.
         playerWeapons.Clear();
-        for (int i = 0; i < 5; i++)
-        {
-            playerWeapons.Add(weapon);
-        }
-        var stat1 = new Stat()
-        {
-            attack = 10
-        };
-        var weapon1 = new Weapon() { statEffect = stat1 };
-        for (int i = 0; i < 5; i++)
-        {
-            playerWeapons.Add(weapon1);
-        }
-
+        playerWeapons.AddRange(player.GetWeaponList());
         battle.CardList = playerWeapons;
         PlayerMonsterInit();
         battle.BattleStart();      
@@ -303,7 +284,7 @@ public class BattlePlayerAttackPanelController : MonoBehaviour
     {
         for (int i = 0; i < HAND_MAX; i++)
         {
-            handCard[i].transform.GetChild(0).GetComponent<Text>().text = $"{battle.CardHand.ElementAt(i).statEffect}";
+            handCard[i].transform.GetChild(0).GetComponent<Text>().text = $"{battle.CardHand.ElementAt(i).name}\n{battle.CardHand.ElementAt(i).statEffect.attack}";
         }
         deckCount.GetComponent<Text>().text = $"{battle.DeckCount()}";
         UpdateBattleState();

--- a/Assets/Scripts/BattlePlayerAttackPanelController.cs
+++ b/Assets/Scripts/BattlePlayerAttackPanelController.cs
@@ -86,7 +86,7 @@ public class BattlePlayerAttackPanelController : MonoBehaviour
     Player player = GameState.Instance.player;
     Monster monster = new Monster(new Stat() 
     { //보스 1의 스탯. 추후에 몬스터 리스트 받아오기로.
-        maxHp = 15,
+        maxHp = 5,
         attack = 6,
         defense = 10,
         speed = 10}

--- a/Assets/Scripts/BattlePlayerAttackPanelController.cs
+++ b/Assets/Scripts/BattlePlayerAttackPanelController.cs
@@ -76,6 +76,7 @@ public class BattlePlayerAttackPanelController : MonoBehaviour
     public bool[] selectCard = new bool[HAND_MAX];
     public List<Weapon> playerWeapons =new List<Weapon>();
     public Battle battle = new Battle();
+    public StageChoice stageChoice;
     //버튼이 토글처럼 되도록 했고, 최대 HAND_MAX(=3)만큼만 선택이 되도록 함.
 
     /*------------------Down 기존 CombatController부분 병합----------------*/
@@ -85,10 +86,10 @@ public class BattlePlayerAttackPanelController : MonoBehaviour
     Player player = GameState.Instance.player;
     Monster monster = new Monster(new Stat() 
     { //보스 1의 스탯. 추후에 몬스터 리스트 받아오기로.
-        maxHp = 120,
+        maxHp = 15,
         attack = 6,
         defense = 10,
-        speed = 15}
+        speed = 10}
     );
 
     public const float MaxSpeedGauge = 200.0f; //스피드게이지 최댓값
@@ -203,6 +204,7 @@ public class BattlePlayerAttackPanelController : MonoBehaviour
         if(monster.isDead) {
             monsterState = combatState.Dead;
             Debug.Log("몬스터 죽음");
+            stageChoice.MoveToNextStage();//TODO: 일단 스테이지를 넘어가기위해 넣어놓음 
         }    
     }
 

--- a/Assets/Scripts/BuffPanelController.cs
+++ b/Assets/Scripts/BuffPanelController.cs
@@ -12,8 +12,7 @@ public class BuffPanelController : MonoBehaviour
     GameObject buffDescription;
     public GameObject buffView;
     public GameObject buffPanel;
-    public GameObject cardSelectPanel;
-
+    public StageChoice stageChoice;
     public GameObject buffSummary;
 
     public bool buffUpdate = false;
@@ -36,8 +35,7 @@ public class BuffPanelController : MonoBehaviour
         buffUpdate = false;
         buffView.GetComponent<Text>().text = str;
         buffSummary.GetComponent<Text>().text = str2;
-        buffPanel.SetActive(false);
-        cardSelectPanel.SetActive(true);
+        stageChoice.MoveToNextStage();
     }
     
     // Update is called once per frame

--- a/Assets/Scripts/Character.cs
+++ b/Assets/Scripts/Character.cs
@@ -94,6 +94,10 @@ public class Player : CharacterBase
     public float hpDrain = 0f; // 일단은 곱연산
     public int money = 100;
     
+    public List<Weapon> GetWeaponList()
+    {
+       return equipmentSlot.GetWeaponsList();
+    }
     public Player(Stat stat) : base(stat) {}
 
     public void AddBuff(StatBuff buff)

--- a/Assets/Scripts/ChestPanelController.cs
+++ b/Assets/Scripts/ChestPanelController.cs
@@ -4,15 +4,13 @@ using UnityEngine;
 using UnityEngine.UI;
 public class ChestPanelController : MonoBehaviour
 {
-    public GameObject cardSelectPanel;
     public GameObject chestPanel;
     public GameObject chestType;
     public GameObject chestDescription;
-
+    public StageChoice stageChoice;
     public void OnClickTreasureButton()
     {
-        chestPanel.SetActive(false);
-        cardSelectPanel.SetActive(true);
+        stageChoice.MoveToNextStage();
     }
     // Start is called before the first frame update
     void Start()

--- a/Assets/Scripts/Equipment.cs
+++ b/Assets/Scripts/Equipment.cs
@@ -6,13 +6,22 @@ using System.Linq;
 [System.Serializable]
 public class EquipmentRank : JsonItem
 {
-    
+   public static Rank rank;
+   public enum Rank
+    {
+        //TODO: 미스틱나오면 추가하기
+        uncommon,common,rare,unique,legendary,
+    }
 }
 
 [System.Serializable]
 public class EquipmentPrefix : JsonItem
 {
-    
+    public static Prefix prefix;
+    public enum Prefix
+    {
+        broken,weak,normal,strong,amazing
+    }
 }
 
 [System.Serializable]

--- a/Assets/Scripts/Equipment.cs
+++ b/Assets/Scripts/Equipment.cs
@@ -17,11 +17,11 @@ public class EquipmentRank : JsonItem
 [System.Serializable]
 public class EquipmentPrefix : JsonItem
 {
-    public static Prefix prefix;
-    public enum Prefix
-    {
+   public static Prefix prefix;
+   public enum Prefix
+   {
         broken,weak,normal,strong,amazing
-    }
+   }
 }
 
 [System.Serializable]
@@ -48,7 +48,13 @@ public class Equipment : JsonItem
     
 }
 
-public class Weapon : Equipment {}
+public class Weapon : Equipment 
+{
+    public enum WeaponType{
+    sword,blunt,spear,dagger,wand
+    }
+    public WeaponType weaponType;
+}
 public class Armor : Equipment {}
 public class Helmet : Equipment {}
 public class Shoes : Equipment {}

--- a/Assets/Scripts/Equipment.cs
+++ b/Assets/Scripts/Equipment.cs
@@ -68,7 +68,10 @@ public class EquipmentSlot
     Helmet helmet;
     Shoes shoes;
     List<Artifact> artifacts = new List<Artifact>();
-
+    public List<Weapon> GetWeaponsList()
+    {
+        return weapons;
+    }
     public void SetEquipment(Equipment equip)
     {
         switch (equip)

--- a/Assets/Scripts/GameState.cs
+++ b/Assets/Scripts/GameState.cs
@@ -35,8 +35,8 @@ class GameState
     }
     
     private static readonly GameState instance = new GameState();
-    static GameState() {}  
-    private GameState() 
+    static GameState() {}
+    private GameState()
     {
         this._player = new Player
         (
@@ -48,9 +48,10 @@ class GameState
                 speed = 12,
                 startSpeedGauge = 1,
                 evasion = 0.05f,
-                critical =0.05f,
+                critical = 0.05f,
             }
-        ) ;
+        );
+     //        this._player.SetEquipment(JsonDB.GetEquipment($"weapon_000"));
     }
     public static GameState Instance  
     {  

--- a/Assets/Scripts/GameState.cs
+++ b/Assets/Scripts/GameState.cs
@@ -49,9 +49,8 @@ class GameState
                 startSpeedGauge = 1,
                 evasion = 0.05f,
                 critical = 0.05f,
-            }
+            }         
         );
-     //        this._player.SetEquipment(JsonDB.GetEquipment($"weapon_000"));
     }
     public static GameState Instance  
     {  

--- a/Assets/Scripts/NpcPanelController.cs
+++ b/Assets/Scripts/NpcPanelController.cs
@@ -21,7 +21,6 @@ public class NpcPanelController : MonoBehaviour
         {
             Button button = GameObject.Find($"NpcItemButton{i + 1}").GetComponent<Button>();
             Equipment item = JsonDB.GetEquipment(NpcItemIds[i]);
-            
             button.transform.Find("ItemName").GetComponent<Text>().text = item.name;
             button.transform.Find("ItemPrice").GetComponent<Text>().text = $"{item.price}G";
             button.onClick.AddListener(() => {

--- a/Assets/Scripts/PlayerBeginnerWeapon.cs
+++ b/Assets/Scripts/PlayerBeginnerWeapon.cs
@@ -1,0 +1,23 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class PlayerBeginnerWeapon : MonoBehaviour
+{
+    Player player = GameState.Instance.player;
+    // Start is called before the first frame update
+    void Start()
+    {
+        for (int i = 0; i < 5; i++)
+        {
+            player.SetEquipment(JsonDB.GetEquipment($"weapon_{i}00"));
+            player.SetEquipment(JsonDB.GetEquipment($"weapon_{i}00"));
+        }
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        
+    }
+}

--- a/Assets/Scripts/PlayerBeginnerWeapon.cs.meta
+++ b/Assets/Scripts/PlayerBeginnerWeapon.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8be70489c84a2bc44a981ea592855c24
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Resources/equipment.json
+++ b/Assets/Scripts/Resources/equipment.json
@@ -1,30 +1,77 @@
-{ "items": [
+{
+  "items": [
     {
-        "id": "sword1",
-        "type": "weapon",
-       "name": "용사의 모형검",
-      "weaponType": "sword",    
-        "price": 10,
-        "statEffect": {
-            "attack": 8
-        }
+      "id": "sword1_common_broken",
+      "type": "weapon",
+      "name": "용사의 모형검",
+      "price": 10,
+      "statEffect": {
+        "attack": 1
+      }
     },
     {
-        "id": "sword2",
-        "type": "weapon",
-        "name": "환자의 대검",
-        "price": 20,
-        "statEffect": {
-            "attack": -3
-        }
+      "id": "blunt1_common_broken",
+      "type": "weapon",
+      "name": "뿅망치",
+      "price": 10,
+      "statEffect": {
+        "attack": 1
+      }
     },
     {
-        "id": "sword3",
-        "type": "weapon",
-        "name": "진혁의 대검",
-        "price": 100,
-        "statEffect": {
-            "attack": 100
-        }
+      "id": "spear1_common_broken",
+      "type": "weapon",
+      "name": "스펀지 삼지창",
+      "price": 10,
+      "statEffect": {
+        "attack": 1
+      }
+    },
+    {
+      "id": "dagger1_common_broken",
+      "type": "weapon",
+      "name": "해적의 단검",
+      "price": 10,
+      "statEffect": {
+        "attack": 1
+      }
+    },
+    {
+      "id": "wand1_common_broken",
+      "type": "weapon",
+      "name": "요술봉",
+      "price": 10,
+      "statEffect": {
+        "attack": 1
+      }
+    },
+    {
+      "id": "sword1",
+      "type": "weapon",
+      "name": "용사의 대검",
+      "price": 10,
+      "statEffect": {
+        "attack": 10
+      }
+    },
+    {
+      "id": "sword2",
+      "type": "weapon",
+      "name": "환자의 대검",
+      "price": 20,
+      "statEffect": {
+        "attack": -3
+      }
+    },
+    {
+      "id": "sword3",
+      "type": "weapon",
+      "name": "진혁의 대검",
+      "price": 100,
+      "statEffect": {
+        "attack": 100
+      }
     }
-]}
+
+  ]
+}

--- a/Assets/Scripts/Resources/equipment.json
+++ b/Assets/Scripts/Resources/equipment.json
@@ -2,7 +2,8 @@
     {
         "id": "sword1",
         "type": "weapon",
-        "name": "용사의 대검",
+       "name": "용사의 모형검",
+      "weaponType": "sword",    
         "price": 10,
         "statEffect": {
             "attack": 8

--- a/Assets/Scripts/Resources/equipment.json
+++ b/Assets/Scripts/Resources/equipment.json
@@ -1,7 +1,7 @@
 {
   "items": [
     {
-      "id": "sword1_common_broken",
+      "id": "weapon_000",
       "type": "weapon",
       "name": "용사의 모형검",
       "price": 10,
@@ -10,7 +10,7 @@
       }
     },
     {
-      "id": "blunt1_common_broken",
+      "id": "weapon_100",
       "type": "weapon",
       "name": "뿅망치",
       "price": 10,
@@ -19,7 +19,7 @@
       }
     },
     {
-      "id": "spear1_common_broken",
+      "id": "weapon_200",
       "type": "weapon",
       "name": "스펀지 삼지창",
       "price": 10,
@@ -28,7 +28,7 @@
       }
     },
     {
-      "id": "dagger1_common_broken",
+      "id": "weapon_300",
       "type": "weapon",
       "name": "해적의 단검",
       "price": 10,
@@ -37,7 +37,7 @@
       }
     },
     {
-      "id": "wand1_common_broken",
+      "id": "weapon_400",
       "type": "weapon",
       "name": "요술봉",
       "price": 10,

--- a/Assets/Scripts/Sprites.meta
+++ b/Assets/Scripts/Sprites.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 78191fb7a39e5de478537cdc0eeb4b83
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Scripts/StageCard.cs
+++ b/Assets/Scripts/StageCard.cs
@@ -32,7 +32,7 @@ public class StageCardGenerator
 {
     public static StageCard GetRandomCard(int world, int stage, int location)
     {
-        int seed = 14 + GameState.Instance.GlobalSeed + world + stage + location;
+        int seed = GameState.Instance.GlobalSeed + world + stage + location;
         var rand = new Random(seed);
 
         CardType type;

--- a/Assets/Scripts/StageCard.cs
+++ b/Assets/Scripts/StageCard.cs
@@ -32,7 +32,7 @@ public class StageCardGenerator
 {
     public static StageCard GetRandomCard(int world, int stage, int location)
     {
-        int seed = GameState.Instance.GlobalSeed + world + stage + location;
+        int seed = 14 + GameState.Instance.GlobalSeed + world + stage + location;
         var rand = new Random(seed);
 
         CardType type;

--- a/Assets/Scripts/StageChoice.cs
+++ b/Assets/Scripts/StageChoice.cs
@@ -53,7 +53,10 @@ public class StageChoice : MonoBehaviour
     // Update is called once per frame
     void Update()
     {
-
+        var stageCards = GameState.Instance.Stage.Cards;
+        CardText1.text = stageCards[0].Type.ToString();
+        CardText2.text = stageCards[1].Type.ToString();
+        CardText3.text = stageCards[2].Type.ToString();
     }
 
     public void OnClickCard(int index)


### PR DESCRIPTION
- 상자,버프 패널에서 확인버튼을 눌렀을 때,  stageChoice.MoveToNextStage() 가 되도록 수정했음.
- json파일에 기본무기 추가 id = "weapon_000"  

> 여기서 첫번째숫자 = 무기 종류 (sword=0 ,blunt=1,spear,dagger,wand)

> 두번째숫자 = 등급 ( uncommon=0,common,rare,unique,legendary,)

> 세번째숫자 =수식어(broken=0,weak,normal,strong,amazing)

- 전투화면에서 전투가 끝났을때(몬스터를 죽였을 때) stageChoice.MoveToNextStage() 가 되도록 수정했음. *몬스터카드를 또 누르면 이미 몬스터가 죽은걸로 처리되서 바로 다음 스테이지로 넘어감.(이부분은 정섭이가 해결해주겠지?) , 전투에서 상대하는 몬스터 수치좀 깎음. (못이기면 못넘어가서..) 
- 플레이어가 기본무기 10개를 가지고 시작할 수 있게 했고, 그 무기 리스트를 받아 전투때 사용되도록 구현함. 핸드의 무기이름이랑 공격력만 뜨도록 바꿈. 