### PR TITLE
동적할당된 버튼이 작동하도록 설정 (일부분만)

### DIFF
--- a/Assets/Scripts/RandomEvent.cs
+++ b/Assets/Scripts/RandomEvent.cs
@@ -3,13 +3,13 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
 using System.Linq;
-public class RandomEvent {
-    RandomPanelController randomPanelController = GameObject.Find("Canvas").transform.Find("RandomPanel").gameObject.GetComponent<RandomPanelController>();
-    private static readonly RandomEvent instance = new RandomEvent();
+public class RandomEvent
+{
+    RandomPanelController randomPanelController =GameObject.Find("Canvas").transform.Find("RandomPanel").gameObject.GetComponent<RandomPanelController>();
     public void PositiveEvent(Text name,Text description,RandomCard randomCard)
     {
         int tempInt;
-        switch (CustomRandom<int>.Choice(new List<int> { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }, GameState.Instance.World.Random)) //case 추가할때 범위도 늘려주자.
+        switch (CustomRandom<int>.Choice(new List<int> { 9, 10 }, GameState.Instance.World.Random)) //case 추가할때 범위도 늘려주자.
         {
 
             case 0:
@@ -67,12 +67,12 @@ public class RandomEvent {
             case 9:
                 name.text = $"카발라의 축복(등급)";
                 description.text = "카발라의 축복" + "\n\n" + $"[선택장비 등급 상승]";
-                CreateButtonEquipments();
+                CreateButtonEquipments(true);
                 break;
             case 10:
                 name.text = $"카발라의 축복(수식어)";
                 description.text = "카발라의 축복" + "\n\n" + $"[선택장비 수식어 상승]";
-                CreateButtonEquipments();
+                CreateButtonEquipments(false);
                 break;
             default:
                 break;
@@ -213,17 +213,13 @@ public class RandomEvent {
                 break;
         }
     }
-    public static RandomEvent Instance
-    {
-        get => instance;
-    }
-    void CreateButtonEquipments()
+    void CreateButtonEquipments(bool isRank) //랭크올리는거면 true, 수식어면 false
     {
         foreach (var weapon in GameState.Instance.player.GetWeaponList())
         {
             randomPanelController.CreateButton(weapon);
         }
-        randomPanelController.CreateButton(GameState.Instance.player.GetHelmet());
+        randomPanelController.CreateButton(GameState.Instance.player.GetHelmet(),isRank);
         randomPanelController.CreateButton(GameState.Instance.player.GetArmor());
         randomPanelController.CreateButton(GameState.Instance.player.GetShoes());
     }

--- a/Assets/Scripts/RandomEvent.cs
+++ b/Assets/Scripts/RandomEvent.cs
@@ -9,7 +9,7 @@ public class RandomEvent
     public void PositiveEvent(Text name,Text description,RandomCard randomCard)
     {
         int tempInt;
-        switch (CustomRandom<int>.Choice(new List<int> { 9, 10 }, GameState.Instance.World.Random)) //case 추가할때 범위도 늘려주자.
+        switch (CustomRandom<int>.Choice(new List<int> { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }, GameState.Instance.World.Random)) //case 추가할때 범위도 늘려주자.
         {
 
             case 0:


### PR DESCRIPTION
- 수식어+등급 올리는 이벤트에서 버튼 누르면 작동하게 설정(지금은 헬멧만 했음)

-  카오마이 버프 누르면 버프 추가되도록 설정

- RandomEvent를 싱글톤으로 하니깐 재시작해도 없어진 게임오브젝트를 계속 지정하고 있어서 싱글톤방식을 없앴음

