### PR TITLE
Monster reward gives heal

### DIFF
--- a/Assets/Scripts/GameConstant.cs
+++ b/Assets/Scripts/GameConstant.cs
@@ -46,8 +46,8 @@ class GameConstant
     public static int[] RewardCoinMax = new int[12] { 0, 25, 35, 45, 60, 90, 90, 100, 110, 110, 130, 150 };
 
     // 몬스터 보상 장비 종류 확률
-    // 무기, 방어구
-    public static List<double> RewardEquipmentType = new List<double> { 0.7, 0.3 };
+    // 무기, 방어구, 힐
+    public static List<double> RewardType = new List<double> { 0.7, 0.27, 0.03 };
     
     // 몬스터 보상 장비 등급 확률
     // common, uncommon, rare, unique, legendary

--- a/Assets/Scripts/RewardPanelController.cs
+++ b/Assets/Scripts/RewardPanelController.cs
@@ -46,33 +46,38 @@ public class RewardPanelController : MonoBehaviour
             for(int i = 0; i < 3; i++)
             {
                 var rewardButton = rewardButtons[i];
-                var rewardEquipment = MonsterCard.rewardEquipments[i];
-                rewardButton.transform.GetChild(0).GetComponent<Text>().text = rewardEquipment.name;
+                var reward = MonsterCard.rewards[i];
+                rewardButton.transform.GetChild(0).GetComponent<Text>().text = reward.title;
                 rewardButton.onClick.RemoveAllListeners();
-                rewardButton.onClick.AddListener(() => OnClickRewardButton(rewardEquipment));
+                rewardButton.onClick.AddListener(() => OnClickRewardButton(reward));
             }
         }
     }
 
-    void OnClickRewardButton(Equipment reward)
+    void OnClickRewardButton(MonsterReward reward)
     {
         Player player = GameState.Instance.player;
-        if (reward.type == "weapon")
+        switch(reward.type)
         {
-            player.SetEquipment(reward);
-            player.money += rewardGetCoin;
-            this.gameObject.SetActive(false);
-            if (player.GetWeaponList().Count > 10)
-                weaponChangePanel.SetActive(true);
-        }
-        else
-        {
-            equipmentChanger.DisplayPanel(reward, (e) => 
-            {
-                player.SetEquipment(e);
+            case MonsterRewardType.Weapon:
+                player.SetEquipment(reward.equipment);
                 player.money += rewardGetCoin;
                 this.gameObject.SetActive(false);
-            });
+                if (player.GetWeaponList().Count > 10)
+                    weaponChangePanel.SetActive(true);
+                break;
+            case MonsterRewardType.Equipment:
+                equipmentChanger.DisplayPanel(reward.equipment, (e) => 
+                {
+                    player.SetEquipment(e);
+                    player.money += rewardGetCoin;
+                    this.gameObject.SetActive(false);
+                });
+                break;
+            case MonsterRewardType.Heal:
+                player.Heal((int)(player.GetStat().maxHp * reward.healPercent));
+                this.gameObject.SetActive(false);
+                break;
         }
     }
 }


### PR DESCRIPTION
아사나 태스크
- https://app.asana.com/0/1199684845846182/1199507811360459/f

한 일
- 몬스터 보상에 힐 추가
- 힐은 최대 체력의 20%
- 랜덤, 상자에서 주는 장비를 몬스터 보상에서 가져오던 걸 상인 판매 장비 로직을 따르도록 수정
    - 힐이 뜨면 안 되니까