### PR TITLE
World 분기점 선택 패널 구현

### DIFF
--- a/Assets/Scenes/MainScene.unity
+++ b/Assets/Scenes/MainScene.unity
@@ -4553,6 +4553,125 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 371515951}
   m_CullTransparentMesh: 0
+--- !u!1 &373560335
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 373560336}
+  - component: {fileID: 373560339}
+  - component: {fileID: 373560338}
+  - component: {fileID: 373560337}
+  m_Layer: 5
+  m_Name: WorldButton1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &373560336
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 373560335}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1086388713}
+  m_Father: {fileID: 1877405126}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -180, y: -480}
+  m_SizeDelta: {x: 200, y: 300}
+  m_Pivot: {x: 0.5, y: 0}
+--- !u!114 &373560337
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 373560335}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 373560338}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &373560338
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 373560335}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &373560339
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 373560335}
+  m_CullTransparentMesh: 0
 --- !u!1 &380729136
 GameObject:
   m_ObjectHideFlags: 0
@@ -14471,6 +14590,84 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1085806406}
   m_CullTransparentMesh: 0
+--- !u!1 &1086388712
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1086388713}
+  - component: {fileID: 1086388715}
+  - component: {fileID: 1086388714}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1086388713
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1086388712}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 373560336}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1086388714
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1086388712}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 40
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 4
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: "\uC6D4\uB4DC 5-1"
+--- !u!222 &1086388715
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1086388712}
+  m_CullTransparentMesh: 0
 --- !u!1 &1100955870
 GameObject:
   m_ObjectHideFlags: 0
@@ -15508,6 +15705,7 @@ RectTransform:
   - {fileID: 1308726067}
   - {fileID: 386927249}
   - {fileID: 1579020816}
+  - {fileID: 1877405126}
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -21102,6 +21300,84 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1722733936}
   m_CullTransparentMesh: 0
+--- !u!1 &1732010634
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1732010635}
+  - component: {fileID: 1732010637}
+  - component: {fileID: 1732010636}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1732010635
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1732010634}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 2028348066}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1732010636
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1732010634}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 40
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 4
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: "\uC6D4\uB4DC 5-2"
+--- !u!222 &1732010637
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1732010634}
+  m_CullTransparentMesh: 0
 --- !u!1 &1732998499
 GameObject:
   m_ObjectHideFlags: 0
@@ -22608,6 +22884,84 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1836456922}
   m_CullTransparentMesh: 0
+--- !u!1 &1839946200
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1839946201}
+  - component: {fileID: 1839946203}
+  - component: {fileID: 1839946202}
+  m_Layer: 5
+  m_Name: Title
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1839946201
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1839946200}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1.35, y: 1.35, z: 1.35}
+  m_Children: []
+  m_Father: {fileID: 1877405126}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 1}
+  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchoredPosition: {x: 0, y: -110}
+  m_SizeDelta: {x: 440, y: 80}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1839946202
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1839946200}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 1}
+  m_RaycastTarget: 1
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 50
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 4
+    m_MaxSize: 50
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: "\uAC08\uB9BC\uAE38"
+--- !u!222 &1839946203
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1839946200}
+  m_CullTransparentMesh: 0
 --- !u!1 &1843424143
 GameObject:
   m_ObjectHideFlags: 0
@@ -22890,6 +23244,97 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1876132962}
+  m_CullTransparentMesh: 0
+--- !u!1 &1877405125
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1877405126}
+  - component: {fileID: 1877405129}
+  - component: {fileID: 1877405128}
+  - component: {fileID: 1877405127}
+  m_Layer: 5
+  m_Name: WorldSelectPanel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1877405126
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1877405125}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1839946201}
+  - {fileID: 1922930659}
+  - {fileID: 373560336}
+  - {fileID: 2028348066}
+  m_Father: {fileID: 1186672458}
+  m_RootOrder: 22
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 1, y: 0.5}
+  m_AnchoredPosition: {x: 2840, y: 3100}
+  m_SizeDelta: {x: 0, y: 1200}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1877405127
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1877405125}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a230d807cd57e49d6aaaec3cd0ea955d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1877405128
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1877405125}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.39215687}
+  m_RaycastTarget: 1
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1877405129
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1877405125}
   m_CullTransparentMesh: 0
 --- !u!1 &1884140794
 GameObject:
@@ -23331,6 +23776,84 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1918254847}
+  m_CullTransparentMesh: 0
+--- !u!1 &1922930658
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1922930659}
+  - component: {fileID: 1922930661}
+  - component: {fileID: 1922930660}
+  m_Layer: 5
+  m_Name: Description
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1922930659
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1922930658}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1877405126}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 180}
+  m_SizeDelta: {x: 800, y: 500}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1922930660
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1922930658}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 40
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 0
+    m_MaxSize: 60
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: "\uC6D4\uB4DC\uB97C \uC120\uD0DD\uD574 \uC8FC\uC138\uC694."
+--- !u!222 &1922930661
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1922930658}
   m_CullTransparentMesh: 0
 --- !u!1 &1929148748
 GameObject:
@@ -24706,6 +25229,125 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2023129620}
+  m_CullTransparentMesh: 0
+--- !u!1 &2028348065
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2028348066}
+  - component: {fileID: 2028348069}
+  - component: {fileID: 2028348068}
+  - component: {fileID: 2028348067}
+  m_Layer: 5
+  m_Name: WorldButton2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2028348066
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2028348065}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1732010635}
+  m_Father: {fileID: 1877405126}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 180, y: -480}
+  m_SizeDelta: {x: 200, y: 300}
+  m_Pivot: {x: 0.5, y: 0}
+--- !u!114 &2028348067
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2028348065}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 2028348068}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &2028348068
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2028348065}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &2028348069
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2028348065}
   m_CullTransparentMesh: 0
 --- !u!1 &2036752256
 GameObject:

--- a/Assets/Scripts/GameConstant.cs
+++ b/Assets/Scripts/GameConstant.cs
@@ -3,6 +3,10 @@ using System.Collections.Generic;
 
 class GameConstant
 {
+    // 크리티컬 배수
+    public const float CRITMULTIPLIER = 2.0f; 
+
+    
     // 플레이어 초기 스탯
     public static Stat PlayerInitialStat = new Stat()
     {
@@ -25,9 +29,6 @@ class GameConstant
     {
         "helmet", "armor", "shoes",
     };
-  
-    // 크리티컬 배수
-    public const float CRITMULTIPLIER = 2.0f; 
 
   
     // 시작 월드 ID

--- a/Assets/Scripts/GameConstant.cs
+++ b/Assets/Scripts/GameConstant.cs
@@ -34,7 +34,7 @@ class GameConstant
     public static WorldId InitialWorldId = WorldId.W1;
 
     // 월드별 보스 등장 스테이지
-    public static int[] BossStage = new int[8] { 15, 20, 20, 20, 20 ,20, 20, 20 };
+    public static int[] BossStage = new int[9] { 15, 20, 20, 20, 25 ,25, 30, 30, 30 };
 
     // 스테이지 카드 등장 확률
     // Monster, Chest, Buff, Npc, Random, Boss

--- a/Assets/Scripts/Resources/monster.json
+++ b/Assets/Scripts/Resources/monster.json
@@ -577,6 +577,78 @@
       }
     },
     {
+      "id": "penguin",
+      "name": "펭귄",
+      "worldId": 6,
+      "isBoss": false,
+      "baseStat": {
+        "maxHp": 400,
+        "attack": 25,
+        "defense": 10,
+        "speed": 60
+      }
+    },
+    {
+      "id": "polar_bear",
+      "name": "북극곰",
+      "worldId": 6,
+      "isBoss": false,
+      "baseStat": {
+        "maxHp": 700,
+        "attack": 60,
+        "defense": 24,
+        "speed": 20
+      }
+    },
+    {
+      "id": "seal",
+      "name": "바다표범",
+      "worldId": 6,
+      "isBoss": false,
+      "baseStat": {
+        "maxHp": 650,
+        "attack": 50,
+        "defense": 20,
+        "speed": 30
+      }
+    },
+    {
+      "id": "teddy_world6",
+      "name": "테디 베어",
+      "worldId": 6,
+      "isBoss": false,
+      "baseStat": {
+        "maxHp": 743,
+        "attack": 29,
+        "defense": 24,
+        "speed": 17
+      }
+    },
+    {
+      "id": "spider_world6",
+      "name": "거미",
+      "worldId": 6,
+      "isBoss": false,
+      "baseStat": {
+        "maxHp": 343,
+        "attack": 41,
+        "defense": 12,
+        "speed": 53
+      }
+    },
+    {
+      "id": "monkey_world6",
+      "name": "심벌치는 원숭이",
+      "worldId": 6,
+      "isBoss": false,
+      "baseStat": {
+        "maxHp": 663,
+        "attack": 49,
+        "defense": 19,
+        "speed": 41
+      }
+    },
+    {
       "id": "fox",
       "name": "여우(삼미호)",
       "worldId": 71,

--- a/Assets/Scripts/Resources/monster.json
+++ b/Assets/Scripts/Resources/monster.json
@@ -577,7 +577,7 @@
       }
     },
     {
-      "id": "penguin",
+      "id": "penguin6",
       "name": "펭귄",
       "worldId": 6,
       "isBoss": false,
@@ -589,7 +589,7 @@
       }
     },
     {
-      "id": "polar_bear",
+      "id": "polar_bear6",
       "name": "북극곰",
       "worldId": 6,
       "isBoss": false,
@@ -601,7 +601,7 @@
       }
     },
     {
-      "id": "seal",
+      "id": "seal6",
       "name": "바다표범",
       "worldId": 6,
       "isBoss": false,

--- a/Assets/Scripts/Resources/monster.json
+++ b/Assets/Scripts/Resources/monster.json
@@ -421,7 +421,7 @@
       }
     },
     {
-      "id": "teddy_world5",
+      "id": "teddy_world5_1",
       "name": "테디 베어",
       "worldId": 51,
       "isBoss": false,
@@ -433,7 +433,7 @@
       }
     },
     {
-      "id": "spider_world5",
+      "id": "spider_world5_1",
       "name": "거미",
       "worldId": 51,
       "isBoss": false,
@@ -445,7 +445,7 @@
       }
     },
     {
-      "id": "monkey_world5",
+      "id": "monkey_world5_1",
       "name": "심벌치는 원숭이",
       "worldId": 51,
       "isBoss": false,
@@ -457,7 +457,7 @@
       }
     },
     {
-      "id": "rabbit_world5",
+      "id": "rabbit_world5_1",
       "name": "북치는 토끼",
       "worldId": 51,
       "isBoss": false,
@@ -517,7 +517,7 @@
       }
     },
     {
-      "id": "teddy_world5.5",
+      "id": "teddy_world5_2",
       "name": "테디 베어",
       "worldId": 52,
       "isBoss": false,
@@ -529,7 +529,7 @@
       }
     },
     {
-      "id": "spider_world5.5",
+      "id": "spider_world5_2",
       "name": "거미",
       "worldId": 52,
       "isBoss": false,
@@ -541,7 +541,7 @@
       }
     },
     {
-      "id": "monkey_world5.5",
+      "id": "monkey_world5_2",
       "name": "심벌치는 원숭이",
       "worldId": 52,
       "isBoss": false,
@@ -553,7 +553,7 @@
       }
     },
     {
-      "id": "rabbit_world5.5",
+      "id": "rabbit_world5_2",
       "name": "북치는 토끼",
       "worldId": 52,
       "isBoss": false,
@@ -697,7 +697,7 @@
       }
     },
     {
-      "id": "bat_world7",
+      "id": "bat_world7_1",
       "name": "박쥐",
       "worldId": 71,
       "isBoss": false,
@@ -709,7 +709,7 @@
       }
     },
     {
-      "id": "queen_spider_world7",
+      "id": "queen_spider_world7_1",
       "name": "퀸 스파이더",
       "worldId": 71,
       "isBoss": false,
@@ -721,7 +721,7 @@
       }
     },
     {
-      "id": "moon_bear_world7",
+      "id": "moon_bear_world7_1",
       "name": "곰인형(반달곰)",
       "worldId": 71,
       "isBoss": false,
@@ -781,7 +781,7 @@
       }
     },
     {
-      "id": "bat_world7.5",
+      "id": "bat_world7_2",
       "name": "박쥐",
       "worldId": 72,
       "isBoss": false,
@@ -793,7 +793,7 @@
       }
     },
     {
-      "id": "queen_spider_world7.5",
+      "id": "queen_spider_world7_2",
       "name": "퀸 스파이더",
       "worldId": 72,
       "isBoss": false,
@@ -805,7 +805,7 @@
       }
     },
     {
-      "id": "moon_bear_world7.5",
+      "id": "moon_bear_world7_2",
       "name": "곰인형(반달곰)",
       "worldId": 72,
       "isBoss": false,

--- a/Assets/Scripts/Resources/monster.json
+++ b/Assets/Scripts/Resources/monster.json
@@ -649,6 +649,18 @@
       }
     },
     {
+      "id": "Doppelganger",
+      "name": "도플갱어",
+      "worldId": 6,
+      "isBoss": true,
+      "baseStat": {
+        "maxHp": 663,
+        "attack": 49,
+        "defense": 19,
+        "speed": 41
+      }
+    },
+    {
       "id": "fox",
       "name": "여우(삼미호)",
       "worldId": 71,

--- a/Assets/Scripts/RewardPanelController.cs
+++ b/Assets/Scripts/RewardPanelController.cs
@@ -63,23 +63,27 @@ public class RewardPanelController : MonoBehaviour
         {
             case MonsterRewardType.Weapon:
                 player.SetEquipment(reward.equipment);
-                player.money += rewardGetCoin;
-                this.gameObject.SetActive(false);
                 if (player.GetWeaponList().Count > 10)
                     weaponChangePanel.SetActive(true);
+                AfterChooseReward();
                 break;
             case MonsterRewardType.Equipment:
                 equipmentChanger.DisplayPanel(reward.equipment, (e) => 
                 {
                     player.SetEquipment(e);
-                    player.money += rewardGetCoin;
-                    this.gameObject.SetActive(false);
+                    AfterChooseReward();
                 });
                 break;
             case MonsterRewardType.Heal:
                 player.Heal((int)(player.GetStat().maxHp * reward.healPercent));
-                this.gameObject.SetActive(false);
+                AfterChooseReward();
                 break;
+        }
+
+        void AfterChooseReward()
+        {
+            player.money += rewardGetCoin;
+            this.gameObject.SetActive(false);
         }
     }
 }

--- a/Assets/Scripts/StageCard.cs
+++ b/Assets/Scripts/StageCard.cs
@@ -387,18 +387,35 @@ public class World
     {
         switch(Id)
         {
-            case WorldId.W4:
+            case WorldId.W4: // default value
                 return WorldId.W5_1;
+            case WorldId.W5_1:
+                return WorldId.W6;
             case WorldId.W5_2:
                 return WorldId.W6;
-            case WorldId.W6:
+            case WorldId.W6: // default value
                 return WorldId.W7_1;
+            case WorldId.W7_1:
+                return WorldId.W8;
             case WorldId.W7_2:
                 return WorldId.W8;
             case WorldId.WX: // TODO: the next world of the last world
                 return WorldId.WX;
             default:
                 return (WorldId)((int)Id + 1);
+        }
+    }
+
+    public WorldId[] GetNextWorldIds()
+    {
+        switch(Id)
+        {
+            case WorldId.W4:
+                return new WorldId[2] { WorldId.W5_1, WorldId.W5_2 };
+            case WorldId.W6:
+                return new WorldId[2] { WorldId.W7_1, WorldId.W7_2 };
+            default:
+                return new WorldId[1] { GetNextWorldId() };
         }
     }
 }

--- a/Assets/Scripts/StageChoice.cs
+++ b/Assets/Scripts/StageChoice.cs
@@ -85,6 +85,8 @@ public class StageChoice : MonoBehaviour
     
     public void MoveToNextWorld()
     {
+        DeactiveAllPanel();
+
         WorldId[] worldIds = GameState.Instance.World.GetNextWorldIds();
         if (worldIds.Length == 1)
             AfterWorldSelected(worldIds[0]);
@@ -99,7 +101,7 @@ public class StageChoice : MonoBehaviour
             GameState.Instance.StartWorld(selectedWorld);
             GameState.Instance.player.Heal(GameState.Instance.player.GetStat().maxHp);
             GameState.Instance.player.HpOver();
-            ActivatePannel();
+            UpdateGamePanel();
         }
     }
 

--- a/Assets/Scripts/StageChoice.cs
+++ b/Assets/Scripts/StageChoice.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
 using UnityEngine;
@@ -21,6 +22,8 @@ public class StageChoice : MonoBehaviour
     GameObject RandomPanel;
     GameObject WeaponPopupView;
     GameObject WeaponChangePanel;
+    
+    WorldSelectPanelController WorldSelect;
 
     Text WorldText;
     Text StageText;
@@ -42,6 +45,8 @@ public class StageChoice : MonoBehaviour
         RandomPanel = GameObject.Find("RandomPanel");
         WeaponChangePanel = GameObject.Find("WeaponChangePanel");
         WeaponPopupView = GameObject.Find("WeaponPopupView/WeaponPopupScreen");
+
+        WorldSelect = GameObject.Find("WorldSelectPanel").GetComponent<WorldSelectPanelController>();
 
         WorldText = GameObject.Find("World Text").GetComponent<Text>();
         StageText = GameObject.Find("Stage Text").GetComponent<Text>();
@@ -80,13 +85,23 @@ public class StageChoice : MonoBehaviour
     
     public void MoveToNextWorld()
     {
-        selectedCard = null;
-        GameState.Instance.StartWorld(GameState.Instance.World.GetNextWorldId());
-        GameState.Instance.player.Heal(GameState.Instance.player.GetStat().maxHp);
-        GameState.Instance.player.HpOver();
-        ActivatePannel();
-    }
+        WorldId[] worldIds = GameState.Instance.World.GetNextWorldIds();
+        if (worldIds.Length == 1)
+            AfterWorldSelected(worldIds[0]);
+        else if (worldIds.Length == 2)
+            WorldSelect.DisplayPanel(worldIds[0], worldIds[1], AfterWorldSelected);
+        else
+            throw new InvalidOperationException($"Invalid number of world ids; {worldIds.Length}");
 
+        void AfterWorldSelected(WorldId selectedWorld)
+        {
+            selectedCard = null;
+            GameState.Instance.StartWorld(selectedWorld);
+            GameState.Instance.player.Heal(GameState.Instance.player.GetStat().maxHp);
+            GameState.Instance.player.HpOver();
+            ActivatePannel();
+        }
+    }
 
     void ActivatePannel()
     {

--- a/Assets/Scripts/WorldSelectPanelController.cs
+++ b/Assets/Scripts/WorldSelectPanelController.cs
@@ -1,0 +1,28 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+
+public class WorldSelectPanelController : MonoBehaviour
+{
+    public delegate void WorldSelectCallback(WorldId selectedWorld);
+
+    Button WorldButton1, WorldButton2;
+
+    void Start()
+    {
+        WorldButton1 = GameObject.Find("WorldSelectPanel/WorldButton1").GetComponent<Button>();
+        WorldButton2 = GameObject.Find("WorldSelectPanel/WorldButton2").GetComponent<Button>();
+
+        this.gameObject.SetActive(false);
+    }
+
+    public void DisplayPanel(WorldId world1, WorldId world2, WorldSelectCallback callback)
+    {
+        WorldButton1.onClick.AddListener(() => callback(world1));
+        WorldButton2.onClick.AddListener(() => callback(world2));
+
+        this.transform.localPosition = StageChoice.PanelDisplayPosition;
+        this.gameObject.SetActive(true);
+    }
+}

--- a/Assets/Scripts/WorldSelectPanelController.cs
+++ b/Assets/Scripts/WorldSelectPanelController.cs
@@ -19,8 +19,18 @@ public class WorldSelectPanelController : MonoBehaviour
 
     public void DisplayPanel(WorldId world1, WorldId world2, WorldSelectCallback callback)
     {
-        WorldButton1.onClick.AddListener(() => callback(world1));
-        WorldButton2.onClick.AddListener(() => callback(world2));
+        WorldButton1.GetComponentInChildren<Text>().text = world1.ToString(); 
+        WorldButton1.onClick.AddListener(() => 
+        {
+            this.gameObject.SetActive(false);
+            callback(world1);
+        });
+        WorldButton2.GetComponentInChildren<Text>().text = world2.ToString();
+        WorldButton2.onClick.AddListener(() => 
+        {
+            this.gameObject.SetActive(false);
+            callback(world2);
+        });
 
         this.transform.localPosition = StageChoice.PanelDisplayPosition;
         this.gameObject.SetActive(true);

--- a/Assets/Scripts/WorldSelectPanelController.cs.meta
+++ b/Assets/Scripts/WorldSelectPanelController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a230d807cd57e49d6aaaec3cd0ea955d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
아사나 태스크
- [World 분기점 선택 패널 구현](https://app.asana.com/0/1199684845846182/1199710418641965/f)

한 일
- `WorldSelectPanel` 추가
- W6 몬스터 임시로 데이터 넣음 (W5_1 데이터 복붙)
- 각 월드 보스 스테이지 값 갱신
- WX의 보스 스테이지 지정
- 몬스터 보상으로 힐을 선택했을 때 코인을 주지 않는 버그 해결