### PR TITLE
방어력수치 조정 + 전투화면에서 콤보배율이 바로 보이도록 설정

### DIFF
--- a/Assets/Scenes/MainScene.unity
+++ b/Assets/Scenes/MainScene.unity
@@ -13285,6 +13285,84 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 931456342}
   m_CullTransparentMesh: 0
+--- !u!1 &931634597
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 931634598}
+  - component: {fileID: 931634600}
+  - component: {fileID: 931634599}
+  m_Layer: 5
+  m_Name: ComboText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &931634598
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 931634597}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1664559588}
+  m_RootOrder: 9
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 318, y: 0}
+  m_SizeDelta: {x: 200, y: 80}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &931634599
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 931634597}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 55
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 5
+    m_MaxSize: 55
+    m_Alignment: 3
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: "\uCF64\uBCF4"
+--- !u!222 &931634600
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 931634597}
+  m_CullTransparentMesh: 0
 --- !u!1 &941372084
 GameObject:
   m_ObjectHideFlags: 0
@@ -20894,6 +20972,7 @@ RectTransform:
   - {fileID: 2084791228}
   - {fileID: 1190780983}
   - {fileID: 318941149}
+  - {fileID: 931634598}
   m_Father: {fileID: 1186672458}
   m_RootOrder: 11
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Scripts/BattleController.cs
+++ b/Assets/Scripts/BattleController.cs
@@ -204,7 +204,6 @@ public class BattleController : MonoBehaviour
           //  player.Heal((int)((tempStat.attack + player.Synergy().attack) * (1f + BattlePanel.comboPercentSum) * player.GetStat().hpDrain));
            
             Debug.Log($"최종데미지 : {finalAttack}");
-            Debug.Log($"x{1f+BattlePanel.comboPercentSum}배");
 
             if(player.GetBuff().doubleAttackPercent != 0) //확률적으로 턴 두번 진행 유물이 있을경우
             {

--- a/Assets/Scripts/BattlePlayerAttackPanelController.cs
+++ b/Assets/Scripts/BattlePlayerAttackPanelController.cs
@@ -91,6 +91,7 @@ public class BattlePlayerAttackPanelController : MonoBehaviour
     Monster monster;
     Text MonsterName;
     Text MonsterHp;
+    Text ComboText;
 
     private readonly float[] comboList ={0.8f, 0.3f, 0.5f }; //종류,등급,수식어 콤보 배수
     private bool[] comboCheck = new bool[3] { false, false, false };
@@ -119,7 +120,42 @@ public class BattlePlayerAttackPanelController : MonoBehaviour
             }
         }
     }
-   
+   float checkCombo()
+    {
+        var comboPercentSum = 0f;
+        var maxCount = (from n in selectCard where n == true select n).Count();
+        var comboCheck = new bool[3] {false, false, false };
+        Weapon[] selectWeapons = new Weapon[3];
+        if (maxCount != 0)
+        {
+            int j = 0;
+            for (int i = HAND_MAX - 1; i >= 0; i--)
+            {
+                if (selectCard[i] == true)
+                {
+                    if (maxCount == 3)
+                    {
+                        selectWeapons[j] = battle.CardHand.ElementAt(i);
+                        j++;
+                    }
+                }
+            }
+        }
+
+        if (maxCount == 3) //콤보 체크
+        {
+            if ((selectWeapons[0].weaponType != WeaponType.none) && (selectWeapons[0].weaponType == selectWeapons[1].weaponType) && (selectWeapons[1].weaponType == selectWeapons[2].weaponType)) comboCheck[0] = true;
+            if ((selectWeapons[0].rank != Rank.none) && (selectWeapons[0].rank == selectWeapons[1].rank) && (selectWeapons[1].rank == selectWeapons[2].rank)) comboCheck[1] = true;
+            if ((selectWeapons[0].prefix != Prefix.none) && (selectWeapons[0].prefix == selectWeapons[1].prefix) && (selectWeapons[1].prefix == selectWeapons[2].prefix)) comboCheck[2] = true;
+        }
+        for (int i = 0; i < 3; i++)
+        {
+            if (comboCheck[i]) comboPercentSum += comboList[i];
+        }
+
+        return comboPercentSum;
+    }
+
     public void OnClickAttack()
     {
         cardDamageSum = 0;
@@ -146,8 +182,7 @@ public class BattlePlayerAttackPanelController : MonoBehaviour
             }          
         }
         if (maxCount == 3) //콤보 체크
-        {
-            
+        {        
             if ((selectWeapons[0].weaponType != WeaponType.none) && (selectWeapons[0].weaponType == selectWeapons[1].weaponType) && (selectWeapons[1].weaponType == selectWeapons[2].weaponType)) comboCheck[0] = true;
             if ((selectWeapons[0].rank != Rank.none) && (selectWeapons[0].rank == selectWeapons[1].rank) && (selectWeapons[1].rank == selectWeapons[2].rank)) comboCheck[1] = true;
             if ((selectWeapons[0].prefix != Prefix.none) && (selectWeapons[0].prefix == selectWeapons[1].prefix) && (selectWeapons[1].prefix == selectWeapons[2].prefix)) comboCheck[2] = true;
@@ -213,7 +248,7 @@ public class BattlePlayerAttackPanelController : MonoBehaviour
     {   
         MonsterName = GameObject.Find("/Canvas/BattlePlayerAttackPanel/MonsterName").GetComponent<Text>();
         MonsterHp = GameObject.Find("/Canvas/BattlePlayerAttackPanel/MonsterHp").GetComponent<Text>();
-
+        ComboText = GameObject.Find("/Canvas/BattlePlayerAttackPanel/ComboText").GetComponent<Text>();
         RewardPanel = GameObject.Find("Canvas").transform.Find("RewardPanel").gameObject;
         WorldClearPanel = GameObject.Find("Canvas").transform.Find("WorldClearPanel").gameObject;
         GameOverPanel = GameObject.Find("Canvas").transform.Find("GameOverPanel").gameObject;
@@ -238,5 +273,7 @@ public class BattlePlayerAttackPanelController : MonoBehaviour
             handCard[i].transform.GetChild(0).GetComponent<Text>().text = $"{battle.CardHand.ElementAt(i).name}\n{battle.CardHand.ElementAt(i).rank}\n{battle.CardHand.ElementAt(i).prefix}\n{battle.CardHand.ElementAt(i).statEffect.attack}";
         }
         deckCount.GetComponent<Text>().text = $"남은 덱: {battle.DeckCount()}";
+        ComboText.text =$"x{1+checkCombo()}배";
+
     }
 }

--- a/Assets/Scripts/Character.cs
+++ b/Assets/Scripts/Character.cs
@@ -364,7 +364,7 @@ public class Player : CharacterBase
 
     public override void TakeHit(float rawDamage) 
     {
-        int damage = Math.Max((int)rawDamage - this.GetStat().defense, 1);
+        int damage = Math.Max((int)(rawDamage * GameConstant.DEFENSE_RATIO / (GameConstant.DEFENSE_RATIO + this.GetStat().defense)), 1);
         
         float evasionRand = UnityEngine.Random.Range(0.0f, 1.0f); //0.0~1.0사이 임의의값
 

--- a/Assets/Scripts/GameConstant.cs
+++ b/Assets/Scripts/GameConstant.cs
@@ -4,15 +4,17 @@ using System.Collections.Generic;
 class GameConstant
 {
     // 크리티컬 배수
-    public const float CRITMULTIPLIER = 2.0f; 
+    public const float CRITMULTIPLIER = 2.0f;
 
+    //앙기모띠 방어구 기본 상수
+    public const int DEFENSE_RATIO = 40;
     
     // 플레이어 초기 스탯
     public static Stat PlayerInitialStat = new Stat()
     {
         maxHp = 40,
         attack = 10,
-        defense = 0,
+        defense = 3,
         speed = 10,
         startSpeedGauge = 1,
         evasion = 0.05f,
@@ -29,7 +31,6 @@ class GameConstant
     {
         "helmet", "armor", "shoes",
     };
-
   
     // 시작 월드 ID
     public static WorldId InitialWorldId = WorldId.W1;


### PR DESCRIPTION
- 방어력 공식을 새로 바꿈   -> 대미지 = 공격력 * 40/(40+방어력) 
- 위에 방어력 공식에서 '40'은 언제든 수정할 수 있게 GameConstant에 넣었음.
- 전투화면에서 공격하기 전에 카드 3개를 누르면 콤보 배율이 화면에서 보이도록 설정함. (콘솔창에 띄우던 콤보배율은 삭제함)