### PR TITLE
스텟중 최대체력,스피드가 1 미만으로 떨어지지 않도록 조정

### DIFF
--- a/Assets/Scripts/Character.cs
+++ b/Assets/Scripts/Character.cs
@@ -336,6 +336,8 @@ public class Player : CharacterBase
     public override Stat GetStat()
     {
         Stat currentstat = this.baseStat + equipmentSlot.GetTotalStat() + buff.GetTotalStat(this.baseStat+ equipmentSlot.GetTotalStat());
+        if (currentstat.maxHp < 1) currentstat.maxHp = 1;
+        if (currentstat.speed < 1) currentstat.speed = 1;
         return currentstat;
     }
 


### PR DESCRIPTION
- 스텟중 최대체력,스피드가 1 미만으로 떨어지지 않도록 조정
- 스피드는 0되면 무한으로 맞으니깐 최소1은 맞추는게 좋을 것같아서 바꿨음 
- 일단은 Player.GetStat()에서 계산한값에서 체력,스피드가 1미만이면 1로 바꾸게 했는데, 다른 좋은 방법있으면 말해주세요
- (관련 task : https://app.asana.com/0/1199684845846182/1199891735103105/f)