### PR TITLE
강화 NPC 마이너 버그 수정

### DIFF
--- a/Assets/Scripts/NpcEnchantController.cs
+++ b/Assets/Scripts/NpcEnchantController.cs
@@ -115,7 +115,9 @@ public class NpcEnchantController : MonoBehaviour
                 WeaponCard.GetComponentInChildren<Text>().text = $"{weapon.statEffect.attack}";
                 WeaponCards[i] = WeaponCard;
             }
-            
+        }
+        if ((beforeCard != null) && (afterCard != null))
+        {
             beforeCard.GetComponentInChildren<Text>().text = "선택된 카드 없음";
             afterCard.GetComponentInChildren<Text>().text = "선택된 카드 없음";
         }

--- a/Assets/Scripts/NpcEnchantController.cs
+++ b/Assets/Scripts/NpcEnchantController.cs
@@ -50,13 +50,13 @@ public class NpcEnchantController : MonoBehaviour
 
     EnchantInfo selectedEnchant;
 
+    bool canEnchant(Weapon weapon)
+        => (weapon.id != "bare_fist") && (weapon.prefix != Prefix.amazing);
+
     void CoinButton()
     {  
-        if (selectedEnchant.Weapon.prefix == Prefix.amazing)
-        {
-            Debug.Log("최대 강화 수식어입니다.");
+        if (!canEnchant(selectedEnchant.Weapon))
             return;
-        }
 
         Player player = GameState.Instance.player;
         if (player.Pay(selectedEnchant.Price))
@@ -84,10 +84,11 @@ public class NpcEnchantController : MonoBehaviour
         beforeCard.GetComponentInChildren<Text>().text = weapon.prefix.ToString();
         afterCard.GetComponentInChildren<Text>().text = selectedEnchant.NextPrefix.ToString();
 
-        if (weapon.id == "bare_fist" || weapon.prefix == Prefix.amazing)
-            enchantButton.GetComponentInChildren<Text>().text = $"강화 불가";
-        else
+        if (canEnchant(weapon))
             enchantButton.GetComponentInChildren<Text>().text = $"{selectedEnchant.Price} Coin  확인";
+        else
+            enchantButton.GetComponentInChildren<Text>().text = $"강화 불가";
+            
     }
 
     void Start()


### PR DESCRIPTION
눈에 띄지는 않지만, 빨간 에러 메시지 나오는 게 싫어서 수정함
- `beforeCard`, `afterCard`가 null일 때 텍스트를 입력하는 버그 수정
- `bare_fist`를 강화하려고 시도하는 버그 수정